### PR TITLE
feat(backend): backend project structure & sparql

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,25 @@
+"""Application configuration."""
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings."""
+    
+    fuseki_host: str = "fuseki"
+    fuseki_port: int = 3030
+    fuseki_dataset: str = "arp"
+    
+    @property
+    def fuseki_query_endpoint(self) -> str:
+        return f"http://{self.fuseki_host}:{self.fuseki_port}/{self.fuseki_dataset}/query"
+    
+    @property
+    def fuseki_update_endpoint(self) -> str:
+        return f"http://{self.fuseki_host}:{self.fuseki_port}/{self.fuseki_dataset}/update"
+
+    class Config:
+        env_prefix = "ARP_"
+
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,16 @@
 from fastapi import FastAPI
 
+from .routers.artworks import router as artworks_router
+from .routers.sparql import router as sparql_router
+
 app = FastAPI(
     title="ArP API",
     description="Artwork Provenance API",
     version="0.1.0",
 )
+
+app.include_router(artworks_router)
+app.include_router(sparql_router)
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,1 @@
+"""Models package."""

--- a/backend/app/models/artwork.py
+++ b/backend/app/models/artwork.py
@@ -1,0 +1,13 @@
+"""Artwork data model."""
+
+from pydantic import BaseModel
+from typing import Optional
+
+
+class Artwork(BaseModel):
+    """Basic artwork model."""
+    
+    uri: str
+    title: str
+    artist: Optional[str] = None
+    description: Optional[str] = None

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Routers package."""

--- a/backend/app/routers/artworks.py
+++ b/backend/app/routers/artworks.py
@@ -1,0 +1,11 @@
+"""Artworks router."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/artworks", tags=["artworks"])
+
+
+@router.get("/")
+async def list_artworks():
+    """List artworks endpoint placeholder."""
+    return {"artworks": []}

--- a/backend/app/routers/sparql.py
+++ b/backend/app/routers/sparql.py
@@ -1,0 +1,29 @@
+"""SPARQL router."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from ..services.sparql_service import sparql_service
+
+router = APIRouter(prefix="/sparql", tags=["sparql"])
+
+
+class QueryRequest(BaseModel):
+    query: str
+
+
+@router.post("/query")
+async def execute_query(request: QueryRequest):
+    """Execute a SPARQL query."""
+    try:
+        results = sparql_service.execute_query(request.query)
+        return {"success": True, "results": results}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@router.get("/status")
+async def check_status():
+    """Check Fuseki connection status."""
+    connected = sparql_service.test_connection()
+    return {"connected": connected}

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services package."""

--- a/backend/app/services/rdf_service.py
+++ b/backend/app/services/rdf_service.py
@@ -1,0 +1,21 @@
+"""RDF service using rdflib."""
+
+from rdflib import Graph
+
+
+class RDFService:
+    """Service for RDF graph operations."""
+    
+    def __init__(self):
+        self.graph = Graph()
+    
+    def parse(self, data: str, format: str = "turtle") -> Graph:
+        """Parse RDF data into a graph."""
+        return self.graph.parse(data=data, format=format)
+    
+    def serialize(self, format: str = "turtle") -> str:
+        """Serialize graph to string."""
+        return self.graph.serialize(format=format)
+
+
+rdf_service = RDFService()

--- a/backend/app/services/sparql_service.py
+++ b/backend/app/services/sparql_service.py
@@ -1,0 +1,30 @@
+"""SPARQL service for Fuseki connection."""
+
+from SPARQLWrapper import SPARQLWrapper, JSON
+from typing import Dict, Any
+
+from ..config import settings
+
+
+class SPARQLService:
+    """Service for executing SPARQL queries against Fuseki."""
+    
+    def __init__(self):
+        self.endpoint = SPARQLWrapper(settings.fuseki_query_endpoint)
+        self.endpoint.setReturnFormat(JSON)
+    
+    def execute_query(self, query: str) -> Dict[str, Any]:
+        """Execute a SPARQL query and return results."""
+        self.endpoint.setQuery(query)
+        return self.endpoint.query().convert()
+    
+    def test_connection(self) -> bool:
+        """Test if Fuseki is reachable."""
+        try:
+            self.execute_query("SELECT * WHERE { ?s ?p ?o } LIMIT 1")
+            return True
+        except Exception:
+            return False
+
+
+sparql_service = SPARQLService()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,6 @@
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
+fastapi>=0.109.0
+uvicorn[standard]>=0.27.0
+pydantic>=2.5.0
+pydantic-settings>=2.1.0
+rdflib>=7.0.0
+SPARQLWrapper>=2.0.0


### PR DESCRIPTION
Extend backend/app with proper structure for the ArP API: 
### Changes
- **Project Structure**: Created modular backend architecture
  - `routers/` - API endpoints (artworks.py, sparql.py)
  - `services/` - Business logic (sparql_service.py, rdf_service.py)
  - `models/` - Pydantic models (artwork.py)
  - [config.py](cci:7://file:///c:/Users/denisa/Master/An2_sem1/Web/PrimeProvenance-ArP/backend/app/config.py:0:0-0:0) - Application configuration
- **Dependencies**: Added rdflib, SPARQLWrapper, pydantic, pydantic-settings to requirements.txt
- **SPARQL Integration**:
  - SPARQLService class for Fuseki connection and query execution
  - `/sparql/status` endpoint to check Fuseki connectivity
  - `/sparql/query` endpoint for SPARQL query execution 
  ### Acceptance Criteria
- [x] Project structure created
- [x] Fuseki connection working
- [x] Basic SPARQL query execution 

Closes #3