### PR TITLE
fix(fuseki): resolve TDB2 configuration and permissions issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     volumes:
       - ./backend:/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    depends_on:
+      - fuseki
 
   fuseki:
     build: ./fuseki

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,6 +1,8 @@
 FROM stain/jena-fuseki:latest
 
-# Copy custom configuration for the ArP dataset
-# This provides a TDB2 persistent dataset with custom endpoint configuration
+USER root
+RUN mkdir -p /fuseki/configuration /fuseki/databases/arp
+
 COPY config/config.ttl /fuseki/configuration/arp.ttl
 
+RUN chown -R 1000:1000 /fuseki

--- a/fuseki/config/config.ttl
+++ b/fuseki/config/config.ttl
@@ -1,3 +1,4 @@
+@prefix :        <#> .
 @prefix fuseki:  <http://jena.apache.org/fuseki#> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .


### PR DESCRIPTION
- Fix Dockerfile to set correct ownership for /fuseki directory (uid 1000)
- Create /fuseki/configuration and /fuseki/databases/arp directories
- Add missing empty prefix declaration in config.ttl (@prefix : <#>)
- Update README with correct build command and troubleshooting docs
- Add backend dependency on fuseki service in docker-compose.yml