### PR TITLE
feat: add external SPARQL integration for DBpedia, Wikidata, and Gett…

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,28 +5,37 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     """Application settings."""
-    
+
+    # Fuseki configuration
     fuseki_host: str
     fuseki_port: int
     fuseki_dataset: str
     fuseki_username: str
     fuseki_password: str
-    
+
+    # External SPARQL endpoints (with defaults)
+    dbpedia_endpoint: str = "https://dbpedia.org/sparql"
+    wikidata_endpoint: str = "https://query.wikidata.org/sparql"
+    getty_endpoint: str = "http://vocab.getty.edu/sparql"
+
+    # Cache settings
+    external_cache_ttl: int = 3600  # seconds (1 hour)
+
     @property
     def fuseki_query_endpoint(self) -> str:
-        return f"http://{self.fuseki_host}:{self.fuseki_port}/{self.fuseki_dataset}/query"
-    
+        return (
+            f"http://{self.fuseki_host}:{self.fuseki_port}/{self.fuseki_dataset}/query"
+        )
+
     @property
     def fuseki_update_endpoint(self) -> str:
-        return f"http://{self.fuseki_host}:{self.fuseki_port}/{self.fuseki_dataset}/update"
+        return (
+            f"http://{self.fuseki_host}:{self.fuseki_port}/{self.fuseki_dataset}/update"
+        )
 
     model_config = SettingsConfigDict(
-        env_prefix="ARP_",
-        env_file=".env",
-        env_file_encoding="utf-8",
-        extra="ignore"
+        env_prefix="ARP_", env_file=".env", env_file_encoding="utf-8", extra="ignore"
     )
 
 
 settings = Settings()
-

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,18 +1,30 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .routers.artworks import router as artworks_router
-from .routers.sparql import router as sparql_router
+from .routers.external import router as external_router
 from .routers.search import router as search_router
+from .routers.sparql import router as sparql_router
 
 app = FastAPI(
     title="ArP API",
-    description="Artwork Provenance API",
+    description="Artwork Provenance API with external SPARQL integration for DBpedia, Wikidata, and Getty AAT",
     version="0.1.0",
+)
+
+# CORS middleware for frontend access
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Configure appropriately for production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(artworks_router, prefix="/api")
 app.include_router(sparql_router, prefix="/api")
 app.include_router(search_router, prefix="/api")
+app.include_router(external_router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/models/external.py
+++ b/backend/app/models/external.py
@@ -1,0 +1,131 @@
+"""Pydantic models for external data enrichment."""
+
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict, Any
+
+
+class LinkedEntity(BaseModel):
+    """A linked entity with URI and label."""
+    uri: Optional[str] = None
+    label: Optional[str] = None
+    name: Optional[str] = None  # Alternative to label (used by DBpedia)
+
+
+class DBpediaArtworkInfo(BaseModel):
+    """DBpedia artwork information."""
+    source: str = "dbpedia"
+    uri: str
+    abstract: Optional[str] = None
+    thumbnail: Optional[str] = None
+    artist: Optional[LinkedEntity] = None
+    museum: Optional[LinkedEntity] = None
+    year: Optional[str] = None
+    dimensions: Optional[Dict[str, str]] = None
+    wikidata_uri: Optional[str] = None
+    error: Optional[str] = None
+
+
+class DBpediaArtistInfo(BaseModel):
+    """DBpedia artist biographical information."""
+    source: str = "dbpedia"
+    uri: str
+    abstract: Optional[str] = None
+    thumbnail: Optional[str] = None
+    birthDate: Optional[str] = None
+    deathDate: Optional[str] = None
+    birthPlace: Optional[LinkedEntity] = None
+    nationality: Optional[str] = None
+    movement: Optional[LinkedEntity] = None
+    wikidata_uri: Optional[str] = None
+    error: Optional[str] = None
+
+
+class WikidataArtworkInfo(BaseModel):
+    """Wikidata artwork metadata."""
+    source: str = "wikidata"
+    uri: str
+    qid: str
+    image: Optional[str] = None
+    inception: Optional[str] = None
+    creator: Optional[LinkedEntity] = None
+    location: Optional[LinkedEntity] = None
+    material: Optional[LinkedEntity] = None
+    genre: Optional[LinkedEntity] = None
+    movement: Optional[LinkedEntity] = None
+    error: Optional[str] = None
+
+
+class WikidataArtistInfo(BaseModel):
+    """Wikidata artist information."""
+    source: str = "wikidata"
+    uri: str
+    qid: str
+    image: Optional[str] = None
+    birthDate: Optional[str] = None
+    deathDate: Optional[str] = None
+    birthPlace: Optional[LinkedEntity] = None
+    nationality: Optional[LinkedEntity] = None
+    occupation: Optional[LinkedEntity] = None
+    movement: Optional[LinkedEntity] = None
+    error: Optional[str] = None
+
+
+class GettyTerm(BaseModel):
+    """Getty AAT term information."""
+    source: str = "getty"
+    uri: str
+    prefLabel: Optional[str] = None
+    scopeNote: Optional[str] = None
+    broader: Optional[LinkedEntity] = None
+    error: Optional[str] = None
+
+
+class ExternalLinks(BaseModel):
+    """External links for an artwork or artist."""
+    dbpedia: Optional[str] = Field(None, description="DBpedia resource URI")
+    wikidata: Optional[str] = Field(None, description="Wikidata entity URI")
+    getty: Optional[List[str]] = Field(None, description="Getty AAT URIs")
+
+
+class ArtworkEnrichment(BaseModel):
+    """Combined enrichment data for an artwork from all external sources."""
+    artwork_id: str
+    dbpedia: Optional[DBpediaArtworkInfo] = None
+    wikidata: Optional[WikidataArtworkInfo] = None
+    getty: Optional[List[GettyTerm]] = None
+    artist_dbpedia: Optional[DBpediaArtistInfo] = None
+    artist_wikidata: Optional[WikidataArtistInfo] = None
+    
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "artwork_id": "artwork_mona_lisa",
+                "dbpedia": {
+                    "source": "dbpedia",
+                    "uri": "http://dbpedia.org/resource/Mona_Lisa",
+                    "abstract": "The Mona Lisa is a half-length portrait painting...",
+                    "thumbnail": "http://commons.wikimedia.org/wiki/Special:FilePath/..."
+                },
+                "wikidata": {
+                    "source": "wikidata",
+                    "uri": "http://www.wikidata.org/entity/Q12418",
+                    "qid": "Q12418",
+                    "image": "http://commons.wikimedia.org/wiki/Special:FilePath/..."
+                }
+            }
+        }
+
+
+class ExternalResourceQuery(BaseModel):
+    """Request model for querying an external resource."""
+    uri: str = Field(..., description="Full URI of the resource to query")
+
+
+class ExternalQueryResponse(BaseModel):
+    """Generic response for external queries."""
+    success: bool
+    data: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    source: str
+    cached: bool = False
+

--- a/backend/app/routers/external.py
+++ b/backend/app/routers/external.py
@@ -1,0 +1,347 @@
+"""External data router for DBpedia, Wikidata, and Getty AAT queries."""
+
+from fastapi import APIRouter, HTTPException, Query, Path
+from typing import Optional, List
+from urllib.parse import unquote
+
+from ..models.external import (
+    DBpediaArtworkInfo,
+    DBpediaArtistInfo,
+    WikidataArtworkInfo,
+    WikidataArtistInfo,
+    GettyTerm,
+    ArtworkEnrichment,
+    ExternalQueryResponse,
+)
+from ..services.external_sparql_service import external_sparql_service
+from ..services.sparql_service import sparql_service
+
+router = APIRouter(prefix="/external", tags=["external"])
+
+
+# =============================================================================
+# DBpedia Endpoints
+# =============================================================================
+
+@router.get(
+    "/dbpedia/artwork/{resource:path}",
+    response_model=ExternalQueryResponse,
+    summary="Query DBpedia for artwork information",
+    description="Fetch artwork metadata from DBpedia including abstract, thumbnail, artist, and museum information."
+)
+async def get_dbpedia_artwork(
+    resource: str = Path(..., description="DBpedia resource name or full URI (e.g., 'Mona_Lisa' or 'http://dbpedia.org/resource/Mona_Lisa')")
+):
+    """Query DBpedia for artwork information."""
+    try:
+        # Normalize to full URI
+        resource = unquote(resource)
+        if not resource.startswith("http"):
+            uri = f"http://dbpedia.org/resource/{resource}"
+        else:
+            uri = resource
+        
+        data = external_sparql_service.get_dbpedia_artwork_info(uri)
+        
+        if "error" in data:
+            return ExternalQueryResponse(
+                success=False,
+                error=data.get("error"),
+                source="dbpedia"
+            )
+        
+        return ExternalQueryResponse(
+            success=True,
+            data=data,
+            source="dbpedia"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error querying DBpedia: {str(e)}")
+
+
+@router.get(
+    "/dbpedia/artist/{resource:path}",
+    response_model=ExternalQueryResponse,
+    summary="Query DBpedia for artist information",
+    description="Fetch artist biographical data from DBpedia including birth/death dates, nationality, and art movement."
+)
+async def get_dbpedia_artist(
+    resource: str = Path(..., description="DBpedia resource name or full URI (e.g., 'Leonardo_da_Vinci')")
+):
+    """Query DBpedia for artist biographical information."""
+    try:
+        resource = unquote(resource)
+        if not resource.startswith("http"):
+            uri = f"http://dbpedia.org/resource/{resource}"
+        else:
+            uri = resource
+        
+        data = external_sparql_service.get_dbpedia_artist_info(uri)
+        
+        if "error" in data:
+            return ExternalQueryResponse(
+                success=False,
+                error=data.get("error"),
+                source="dbpedia"
+            )
+        
+        return ExternalQueryResponse(
+            success=True,
+            data=data,
+            source="dbpedia"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error querying DBpedia: {str(e)}")
+
+
+# =============================================================================
+# Wikidata Endpoints
+# =============================================================================
+
+@router.get(
+    "/wikidata/artwork/{entity}",
+    response_model=ExternalQueryResponse,
+    summary="Query Wikidata for artwork information",
+    description="Fetch artwork metadata from Wikidata including image, inception date, materials, and location."
+)
+async def get_wikidata_artwork(
+    entity: str = Path(..., description="Wikidata Q-ID or full URI (e.g., 'Q12418' or 'http://www.wikidata.org/entity/Q12418')")
+):
+    """Query Wikidata for artwork metadata."""
+    try:
+        entity = unquote(entity)
+        data = external_sparql_service.get_wikidata_artwork_info(entity)
+        
+        if "error" in data:
+            return ExternalQueryResponse(
+                success=False,
+                error=data.get("error"),
+                source="wikidata"
+            )
+        
+        return ExternalQueryResponse(
+            success=True,
+            data=data,
+            source="wikidata"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error querying Wikidata: {str(e)}")
+
+
+@router.get(
+    "/wikidata/artist/{entity}",
+    response_model=ExternalQueryResponse,
+    summary="Query Wikidata for artist information",
+    description="Fetch artist biographical data from Wikidata including birth/death dates, nationality, and occupation."
+)
+async def get_wikidata_artist(
+    entity: str = Path(..., description="Wikidata Q-ID or full URI (e.g., 'Q762' for Leonardo da Vinci)")
+):
+    """Query Wikidata for artist information."""
+    try:
+        entity = unquote(entity)
+        data = external_sparql_service.get_wikidata_artist_info(entity)
+        
+        if "error" in data:
+            return ExternalQueryResponse(
+                success=False,
+                error=data.get("error"),
+                source="wikidata"
+            )
+        
+        return ExternalQueryResponse(
+            success=True,
+            data=data,
+            source="wikidata"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error querying Wikidata: {str(e)}")
+
+
+# =============================================================================
+# Getty AAT Endpoints
+# =============================================================================
+
+@router.get(
+    "/getty/{aat_id}",
+    response_model=ExternalQueryResponse,
+    summary="Query Getty AAT for term information",
+    description="Fetch term information from Getty Art & Architecture Thesaurus including preferred label and scope note."
+)
+async def get_getty_term(
+    aat_id: str = Path(..., description="Getty AAT ID (e.g., '300015050' for oil paint) or full URI")
+):
+    """Query Getty AAT for art terminology."""
+    try:
+        aat_id = unquote(aat_id)
+        data = external_sparql_service.get_getty_term(aat_id)
+        
+        if "error" in data:
+            return ExternalQueryResponse(
+                success=False,
+                error=data.get("error"),
+                source="getty"
+            )
+        
+        return ExternalQueryResponse(
+            success=True,
+            data=data,
+            source="getty"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error querying Getty AAT: {str(e)}")
+
+
+# =============================================================================
+# Artwork Enrichment Endpoint
+# =============================================================================
+
+# Namespace constants (match those in artwork_service.py)
+ARP_NS = "http://example.org/arp#"
+OWL_NS = "http://www.w3.org/2002/07/owl#"
+SCHEMA_NS = "http://schema.org/"
+
+
+@router.get(
+    "/enrich/{artwork_id}",
+    response_model=ArtworkEnrichment,
+    summary="Enrich artwork with external data",
+    description="""
+    Fetch and combine external data for an artwork from DBpedia, Wikidata, and Getty AAT.
+    
+    This endpoint:
+    1. Queries the local Fuseki triplestore for owl:sameAs links
+    2. Fetches data from each linked external source
+    3. Returns combined enrichment data
+    
+    Results are cached for performance.
+    """
+)
+async def enrich_artwork(
+    artwork_id: str = Path(..., description="Artwork ID (e.g., 'artwork_mona_lisa')")
+):
+    """Enrich artwork data from external sources."""
+    try:
+        # Build full URI
+        if not artwork_id.startswith("http"):
+            artwork_uri = f"{ARP_NS}{artwork_id}"
+        else:
+            artwork_uri = artwork_id
+        
+        # Query local Fuseki for owl:sameAs links and Getty material URIs
+        query = f"""
+        PREFIX owl: <{OWL_NS}>
+        PREFIX schema: <{SCHEMA_NS}>
+        PREFIX arp: <{ARP_NS}>
+        PREFIX dc: <http://purl.org/dc/elements/1.1/>
+        
+        SELECT ?sameAs ?artMedium ?artistUri ?artistSameAs WHERE {{
+            <{artwork_uri}> a arp:Artwork .
+            OPTIONAL {{ <{artwork_uri}> owl:sameAs ?sameAs }}
+            OPTIONAL {{ <{artwork_uri}> schema:artMedium ?artMedium }}
+            OPTIONAL {{ 
+                <{artwork_uri}> dc:creator ?artistUri .
+                OPTIONAL {{ ?artistUri owl:sameAs ?artistSameAs }}
+            }}
+        }}
+        """
+        
+        try:
+            result = sparql_service.execute_query(query)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error querying local triplestore: {str(e)}")
+        
+        if not result.get("results", {}).get("bindings"):
+            raise HTTPException(status_code=404, detail=f"Artwork '{artwork_id}' not found")
+        
+        # Extract URIs from results
+        dbpedia_uri = None
+        wikidata_uri = None
+        getty_uris = []
+        artist_dbpedia_uri = None
+        artist_wikidata_uri = None
+        
+        for binding in result["results"]["bindings"]:
+            # Extract sameAs links
+            same_as = binding.get("sameAs", {}).get("value", "")
+            if "dbpedia.org" in same_as:
+                dbpedia_uri = same_as
+            elif "wikidata.org" in same_as:
+                wikidata_uri = same_as
+            
+            # Extract Getty material URIs
+            art_medium = binding.get("artMedium", {}).get("value", "")
+            if "vocab.getty.edu" in art_medium and art_medium not in getty_uris:
+                getty_uris.append(art_medium)
+            
+            # Extract artist sameAs links
+            artist_same_as = binding.get("artistSameAs", {}).get("value", "")
+            if "dbpedia.org" in artist_same_as:
+                artist_dbpedia_uri = artist_same_as
+            elif "wikidata.org" in artist_same_as:
+                artist_wikidata_uri = artist_same_as
+        
+        # Fetch external data
+        enrichment = ArtworkEnrichment(artwork_id=artwork_id)
+        
+        if dbpedia_uri:
+            data = external_sparql_service.get_dbpedia_artwork_info(dbpedia_uri)
+            if "error" not in data:
+                enrichment.dbpedia = DBpediaArtworkInfo(**data)
+        
+        if wikidata_uri:
+            data = external_sparql_service.get_wikidata_artwork_info(wikidata_uri)
+            if "error" not in data:
+                enrichment.wikidata = WikidataArtworkInfo(**data)
+        
+        if getty_uris:
+            getty_terms = []
+            for uri in getty_uris:
+                data = external_sparql_service.get_getty_term(uri)
+                if "error" not in data:
+                    getty_terms.append(GettyTerm(**data))
+            enrichment.getty = getty_terms if getty_terms else None
+        
+        if artist_dbpedia_uri:
+            data = external_sparql_service.get_dbpedia_artist_info(artist_dbpedia_uri)
+            if "error" not in data:
+                enrichment.artist_dbpedia = DBpediaArtistInfo(**data)
+        
+        if artist_wikidata_uri:
+            data = external_sparql_service.get_wikidata_artist_info(artist_wikidata_uri)
+            if "error" not in data:
+                enrichment.artist_wikidata = WikidataArtistInfo(**data)
+        
+        return enrichment
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error enriching artwork: {str(e)}")
+
+
+# =============================================================================
+# Cache Management
+# =============================================================================
+
+@router.post(
+    "/cache/clear",
+    summary="Clear external query cache",
+    description="Clear all cached external query results."
+)
+async def clear_cache():
+    """Clear the external query cache."""
+    external_sparql_service.cache.clear()
+    return {"message": "Cache cleared successfully"}
+
+
+@router.post(
+    "/cache/cleanup",
+    summary="Cleanup expired cache entries",
+    description="Remove expired entries from the cache."
+)
+async def cleanup_cache():
+    """Remove expired entries from the cache."""
+    removed = external_sparql_service.cache.cleanup()
+    return {"message": f"Removed {removed} expired cache entries"}
+

--- a/backend/app/services/external_sparql_service.py
+++ b/backend/app/services/external_sparql_service.py
@@ -1,0 +1,606 @@
+"""External SPARQL service for DBpedia, Wikidata, and Getty AAT integration."""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from SPARQLWrapper import JSON, SPARQLWrapper
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleCache:
+    """Simple TTL-based in-memory cache for external query results."""
+
+    def __init__(self, ttl: int = 3600):
+        """Initialize cache with TTL in seconds."""
+        self._cache: Dict[str, tuple] = {}  # key -> (value, expiry_time)
+        self._ttl = ttl
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get value from cache if not expired."""
+        if key in self._cache:
+            value, expiry = self._cache[key]
+            if time.time() < expiry:
+                logger.debug("Cache hit for key: %s...", key[:50])
+                return value
+            else:
+                # Expired, remove from cache
+                del self._cache[key]
+                logger.debug("Cache expired for key: %s...", key[:50])
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        """Set value in cache with TTL."""
+        expiry = time.time() + self._ttl
+        self._cache[key] = (value, expiry)
+        logger.debug("Cache set for key: %s...", key[:50])
+
+    def clear(self) -> None:
+        """Clear all cached values."""
+        self._cache.clear()
+
+    def cleanup(self) -> int:
+        """Remove expired entries and return count of removed items."""
+        now = time.time()
+        expired_keys = [k for k, (_, expiry) in self._cache.items() if now >= expiry]
+        for key in expired_keys:
+            del self._cache[key]
+        return len(expired_keys)
+
+
+class ExternalSPARQLService:
+    """Service for querying external SPARQL endpoints (DBpedia, Wikidata, Getty)."""
+
+    # RDF Namespace prefixes
+    PREFIXES = {
+        "dbo": "http://dbpedia.org/ontology/",
+        "dbr": "http://dbpedia.org/resource/",
+        "dbp": "http://dbpedia.org/property/",
+        "wd": "http://www.wikidata.org/entity/",
+        "wdt": "http://www.wikidata.org/prop/direct/",
+        "wikibase": "http://wikiba.se/ontology#",
+        "bd": "http://www.bigdata.com/rdf#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "gvp": "http://vocab.getty.edu/ontology#",
+        "schema": "http://schema.org/",
+        "owl": "http://www.w3.org/2002/07/owl#",
+    }
+
+    def __init__(self):
+        """Initialize external SPARQL service with endpoints and cache."""
+        self.cache = SimpleCache(ttl=settings.external_cache_ttl)
+
+        # Initialize DBpedia client
+        self.dbpedia = SPARQLWrapper(settings.dbpedia_endpoint)
+        self.dbpedia.setReturnFormat(JSON)
+        self.dbpedia.setTimeout(30)
+        self.dbpedia.addCustomHttpHeader("User-Agent", "ArP-Artwork-Provenance/1.0")
+
+        # Initialize Wikidata client
+        self.wikidata = SPARQLWrapper(settings.wikidata_endpoint)
+        self.wikidata.setReturnFormat(JSON)
+        self.wikidata.setTimeout(30)
+        self.wikidata.addCustomHttpHeader("User-Agent", "ArP-Artwork-Provenance/1.0")
+
+        # Initialize Getty client
+        self.getty = SPARQLWrapper(settings.getty_endpoint)
+        self.getty.setReturnFormat(JSON)
+        self.getty.setTimeout(30)
+        self.getty.addCustomHttpHeader("User-Agent", "ArP-Artwork-Provenance/1.0")
+
+    def _execute_query(
+        self, client: SPARQLWrapper, query: str, cache_key: str
+    ) -> Optional[Dict]:
+        """Execute a SPARQL query with caching and error handling."""
+        # Check cache first
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            client.setQuery(query)
+            results = client.query().convert()
+
+            # Cache the results
+            self.cache.set(cache_key, results)
+            return results
+
+        except Exception as e:
+            logger.error("SPARQL query failed: %s", e)
+            logger.debug("Query was: %s...", query[:200])
+            return None
+
+    def _extract_value(self, binding: Dict, key: str) -> Optional[str]:
+        """Safely extract a value from a SPARQL binding."""
+        if key in binding and "value" in binding[key]:
+            return binding[key]["value"]
+        return None
+
+    # =========================================================================
+    # DBpedia Methods
+    # =========================================================================
+
+    def get_dbpedia_artwork_info(self, dbpedia_uri: str) -> Dict[str, Any]:
+        """
+        Fetch artwork information from DBpedia.
+
+        Args:
+            dbpedia_uri: Full DBpedia URI (e.g., http://dbpedia.org/resource/Mona_Lisa)
+
+        Returns:
+            Dictionary with abstract, thumbnail, artist, and other metadata
+        """
+        cache_key = f"dbpedia:artwork:{dbpedia_uri}"
+
+        query = f"""
+        PREFIX dbo: <{self.PREFIXES['dbo']}>
+        PREFIX dbp: <{self.PREFIXES['dbp']}>
+        PREFIX rdfs: <{self.PREFIXES['rdfs']}>
+        PREFIX owl: <{self.PREFIXES['owl']}>
+        
+        SELECT ?abstract ?thumbnail ?artist ?artistName ?museum ?museumName 
+               ?year ?width ?height ?wikidata WHERE {{
+            <{dbpedia_uri}> dbo:abstract ?abstract .
+            FILTER(LANG(?abstract) = "en")
+            
+            OPTIONAL {{ <{dbpedia_uri}> dbo:thumbnail ?thumbnail }}
+            OPTIONAL {{ 
+                <{dbpedia_uri}> dbo:author ?artist .
+                ?artist rdfs:label ?artistName .
+                FILTER(LANG(?artistName) = "en")
+            }}
+            OPTIONAL {{ 
+                <{dbpedia_uri}> dbo:museum ?museum .
+                ?museum rdfs:label ?museumName .
+                FILTER(LANG(?museumName) = "en")
+            }}
+            OPTIONAL {{ <{dbpedia_uri}> dbp:year ?year }}
+            OPTIONAL {{ <{dbpedia_uri}> dbp:widthMetric ?width }}
+            OPTIONAL {{ <{dbpedia_uri}> dbp:heightMetric ?height }}
+            OPTIONAL {{ <{dbpedia_uri}> owl:sameAs ?wikidata . FILTER(CONTAINS(STR(?wikidata), "wikidata")) }}
+        }}
+        LIMIT 1
+        """
+
+        results = self._execute_query(self.dbpedia, query, cache_key)
+
+        if not results or not results.get("results", {}).get("bindings"):
+            return {"error": "No data found", "source": "dbpedia", "uri": dbpedia_uri}
+
+        binding = results["results"]["bindings"][0]
+
+        return {
+            "source": "dbpedia",
+            "uri": dbpedia_uri,
+            "abstract": self._extract_value(binding, "abstract"),
+            "thumbnail": self._extract_value(binding, "thumbnail"),
+            "artist": (
+                {
+                    "uri": self._extract_value(binding, "artist"),
+                    "name": self._extract_value(binding, "artistName"),
+                }
+                if self._extract_value(binding, "artist")
+                else None
+            ),
+            "museum": (
+                {
+                    "uri": self._extract_value(binding, "museum"),
+                    "name": self._extract_value(binding, "museumName"),
+                }
+                if self._extract_value(binding, "museum")
+                else None
+            ),
+            "year": self._extract_value(binding, "year"),
+            "dimensions": (
+                {
+                    "width": self._extract_value(binding, "width"),
+                    "height": self._extract_value(binding, "height"),
+                }
+                if self._extract_value(binding, "width")
+                else None
+            ),
+            "wikidata_uri": self._extract_value(binding, "wikidata"),
+        }
+
+    def get_dbpedia_artist_info(self, dbpedia_uri: str) -> Dict[str, Any]:
+        """
+        Fetch artist biographical information from DBpedia.
+
+        Args:
+            dbpedia_uri: Full DBpedia URI (e.g., http://dbpedia.org/resource/Leonardo_da_Vinci)
+
+        Returns:
+            Dictionary with biography, birth/death dates, nationality, and notable works
+        """
+        cache_key = f"dbpedia:artist:{dbpedia_uri}"
+
+        query = f"""
+        PREFIX dbo: <{self.PREFIXES['dbo']}>
+        PREFIX dbp: <{self.PREFIXES['dbp']}>
+        PREFIX rdfs: <{self.PREFIXES['rdfs']}>
+        PREFIX owl: <{self.PREFIXES['owl']}>
+        
+        SELECT ?abstract ?thumbnail ?birthDate ?deathDate ?birthPlace ?birthPlaceName
+               ?nationality ?movement ?movementName ?wikidata WHERE {{
+            <{dbpedia_uri}> dbo:abstract ?abstract .
+            FILTER(LANG(?abstract) = "en")
+            
+            OPTIONAL {{ <{dbpedia_uri}> dbo:thumbnail ?thumbnail }}
+            OPTIONAL {{ <{dbpedia_uri}> dbo:birthDate ?birthDate }}
+            OPTIONAL {{ <{dbpedia_uri}> dbo:deathDate ?deathDate }}
+            OPTIONAL {{ 
+                <{dbpedia_uri}> dbo:birthPlace ?birthPlace .
+                ?birthPlace rdfs:label ?birthPlaceName .
+                FILTER(LANG(?birthPlaceName) = "en")
+            }}
+            OPTIONAL {{ <{dbpedia_uri}> dbo:nationality ?nationality }}
+            OPTIONAL {{ 
+                <{dbpedia_uri}> dbo:movement ?movement .
+                ?movement rdfs:label ?movementName .
+                FILTER(LANG(?movementName) = "en")
+            }}
+            OPTIONAL {{ <{dbpedia_uri}> owl:sameAs ?wikidata . FILTER(CONTAINS(STR(?wikidata), "wikidata")) }}
+        }}
+        LIMIT 1
+        """
+
+        results = self._execute_query(self.dbpedia, query, cache_key)
+
+        if not results or not results.get("results", {}).get("bindings"):
+            return {"error": "No data found", "source": "dbpedia", "uri": dbpedia_uri}
+
+        binding = results["results"]["bindings"][0]
+
+        return {
+            "source": "dbpedia",
+            "uri": dbpedia_uri,
+            "abstract": self._extract_value(binding, "abstract"),
+            "thumbnail": self._extract_value(binding, "thumbnail"),
+            "birthDate": self._extract_value(binding, "birthDate"),
+            "deathDate": self._extract_value(binding, "deathDate"),
+            "birthPlace": (
+                {
+                    "uri": self._extract_value(binding, "birthPlace"),
+                    "name": self._extract_value(binding, "birthPlaceName"),
+                }
+                if self._extract_value(binding, "birthPlace")
+                else None
+            ),
+            "nationality": self._extract_value(binding, "nationality"),
+            "movement": (
+                {
+                    "uri": self._extract_value(binding, "movement"),
+                    "name": self._extract_value(binding, "movementName"),
+                }
+                if self._extract_value(binding, "movement")
+                else None
+            ),
+            "wikidata_uri": self._extract_value(binding, "wikidata"),
+        }
+
+    # =========================================================================
+    # Wikidata Methods
+    # =========================================================================
+
+    def get_wikidata_artwork_info(self, wikidata_uri: str) -> Dict[str, Any]:
+        """
+        Fetch artwork metadata from Wikidata.
+
+        Args:
+            wikidata_uri: Full Wikidata URI (e.g., http://www.wikidata.org/entity/Q12418)
+                          or just the Q-ID (e.g., Q12418)
+
+        Returns:
+            Dictionary with image, inception date, materials, creator, and location
+        """
+        # Extract Q-ID from URI if needed
+        if "/" in wikidata_uri:
+            qid = wikidata_uri.split("/")[-1]
+        else:
+            qid = wikidata_uri
+
+        cache_key = f"wikidata:artwork:{qid}"
+
+        query = f"""
+        PREFIX wd: <{self.PREFIXES['wd']}>
+        PREFIX wdt: <{self.PREFIXES['wdt']}>
+        PREFIX wikibase: <{self.PREFIXES['wikibase']}>
+        PREFIX bd: <{self.PREFIXES['bd']}>
+        
+        SELECT ?image ?inception ?creator ?creatorLabel ?location ?locationLabel
+               ?material ?materialLabel ?genre ?genreLabel ?movement ?movementLabel WHERE {{
+            OPTIONAL {{ wd:{qid} wdt:P18 ?image }}
+            OPTIONAL {{ wd:{qid} wdt:P571 ?inception }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P170 ?creator .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P276 ?location .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P186 ?material .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P136 ?genre .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P135 ?movement .
+            }}
+            SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en,fr,de,es,it" }}
+        }}
+        LIMIT 1
+        """
+
+        results = self._execute_query(self.wikidata, query, cache_key)
+
+        if not results or not results.get("results", {}).get("bindings"):
+            return {"error": "No data found", "source": "wikidata", "uri": wikidata_uri}
+
+        binding = results["results"]["bindings"][0]
+
+        return {
+            "source": "wikidata",
+            "uri": f"http://www.wikidata.org/entity/{qid}",
+            "qid": qid,
+            "image": self._extract_value(binding, "image"),
+            "inception": self._extract_value(binding, "inception"),
+            "creator": (
+                {
+                    "uri": self._extract_value(binding, "creator"),
+                    "label": self._extract_value(binding, "creatorLabel"),
+                }
+                if self._extract_value(binding, "creator")
+                else None
+            ),
+            "location": (
+                {
+                    "uri": self._extract_value(binding, "location"),
+                    "label": self._extract_value(binding, "locationLabel"),
+                }
+                if self._extract_value(binding, "location")
+                else None
+            ),
+            "material": (
+                {
+                    "uri": self._extract_value(binding, "material"),
+                    "label": self._extract_value(binding, "materialLabel"),
+                }
+                if self._extract_value(binding, "material")
+                else None
+            ),
+            "genre": (
+                {
+                    "uri": self._extract_value(binding, "genre"),
+                    "label": self._extract_value(binding, "genreLabel"),
+                }
+                if self._extract_value(binding, "genre")
+                else None
+            ),
+            "movement": (
+                {
+                    "uri": self._extract_value(binding, "movement"),
+                    "label": self._extract_value(binding, "movementLabel"),
+                }
+                if self._extract_value(binding, "movement")
+                else None
+            ),
+        }
+
+    def get_wikidata_artist_info(self, wikidata_uri: str) -> Dict[str, Any]:
+        """
+        Fetch artist information from Wikidata.
+
+        Args:
+            wikidata_uri: Full Wikidata URI or Q-ID
+
+        Returns:
+            Dictionary with biographical data and notable works
+        """
+        # Extract Q-ID from URI if needed
+        if "/" in wikidata_uri:
+            qid = wikidata_uri.split("/")[-1]
+        else:
+            qid = wikidata_uri
+
+        cache_key = f"wikidata:artist:{qid}"
+
+        query = f"""
+        PREFIX wd: <{self.PREFIXES['wd']}>
+        PREFIX wdt: <{self.PREFIXES['wdt']}>
+        PREFIX wikibase: <{self.PREFIXES['wikibase']}>
+        PREFIX bd: <{self.PREFIXES['bd']}>
+        
+        SELECT ?image ?birthDate ?deathDate ?birthPlace ?birthPlaceLabel
+               ?nationality ?nationalityLabel ?occupation ?occupationLabel
+               ?movement ?movementLabel WHERE {{
+            OPTIONAL {{ wd:{qid} wdt:P18 ?image }}
+            OPTIONAL {{ wd:{qid} wdt:P569 ?birthDate }}
+            OPTIONAL {{ wd:{qid} wdt:P570 ?deathDate }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P19 ?birthPlace .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P27 ?nationality .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P106 ?occupation .
+            }}
+            OPTIONAL {{ 
+                wd:{qid} wdt:P135 ?movement .
+            }}
+            SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en,fr,de,es,it" }}
+        }}
+        LIMIT 1
+        """
+
+        results = self._execute_query(self.wikidata, query, cache_key)
+
+        if not results or not results.get("results", {}).get("bindings"):
+            return {"error": "No data found", "source": "wikidata", "uri": wikidata_uri}
+
+        binding = results["results"]["bindings"][0]
+
+        return {
+            "source": "wikidata",
+            "uri": f"http://www.wikidata.org/entity/{qid}",
+            "qid": qid,
+            "image": self._extract_value(binding, "image"),
+            "birthDate": self._extract_value(binding, "birthDate"),
+            "deathDate": self._extract_value(binding, "deathDate"),
+            "birthPlace": (
+                {
+                    "uri": self._extract_value(binding, "birthPlace"),
+                    "label": self._extract_value(binding, "birthPlaceLabel"),
+                }
+                if self._extract_value(binding, "birthPlace")
+                else None
+            ),
+            "nationality": (
+                {
+                    "uri": self._extract_value(binding, "nationality"),
+                    "label": self._extract_value(binding, "nationalityLabel"),
+                }
+                if self._extract_value(binding, "nationality")
+                else None
+            ),
+            "occupation": (
+                {
+                    "uri": self._extract_value(binding, "occupation"),
+                    "label": self._extract_value(binding, "occupationLabel"),
+                }
+                if self._extract_value(binding, "occupation")
+                else None
+            ),
+            "movement": (
+                {
+                    "uri": self._extract_value(binding, "movement"),
+                    "label": self._extract_value(binding, "movementLabel"),
+                }
+                if self._extract_value(binding, "movement")
+                else None
+            ),
+        }
+
+    # =========================================================================
+    # Getty AAT Methods
+    # =========================================================================
+
+    def get_getty_term(self, aat_uri: str) -> Dict[str, Any]:
+        """
+        Fetch term information from Getty Art & Architecture Thesaurus.
+
+        Args:
+            aat_uri: Full Getty AAT URI (e.g., http://vocab.getty.edu/aat/300015050)
+                     or just the AAT ID (e.g., 300015050)
+
+        Returns:
+            Dictionary with preferred label, scope note, and hierarchy
+        """
+        # Normalize URI
+        if not aat_uri.startswith("http"):
+            aat_uri = f"http://vocab.getty.edu/aat/{aat_uri}"
+
+        cache_key = f"getty:aat:{aat_uri}"
+
+        query = f"""
+        PREFIX skos: <{self.PREFIXES['skos']}>
+        PREFIX gvp: <{self.PREFIXES['gvp']}>
+        PREFIX rdfs: <{self.PREFIXES['rdfs']}>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        
+        SELECT ?prefLabel ?scopeNote ?broader ?broaderLabel WHERE {{
+            <{aat_uri}> skos:prefLabel ?prefLabel .
+            FILTER(LANG(?prefLabel) = "en" || LANG(?prefLabel) = "")
+            
+            OPTIONAL {{ 
+                <{aat_uri}> skos:scopeNote [rdf:value ?scopeNote] .
+                FILTER(LANG(?scopeNote) = "en" || LANG(?scopeNote) = "")
+            }}
+            OPTIONAL {{
+                <{aat_uri}> gvp:broaderGeneric ?broader .
+                ?broader skos:prefLabel ?broaderLabel .
+                FILTER(LANG(?broaderLabel) = "en" || LANG(?broaderLabel) = "")
+            }}
+        }}
+        LIMIT 1
+        """
+
+        results = self._execute_query(self.getty, query, cache_key)
+
+        if not results or not results.get("results", {}).get("bindings"):
+            return {"error": "No data found", "source": "getty", "uri": aat_uri}
+
+        binding = results["results"]["bindings"][0]
+
+        return {
+            "source": "getty",
+            "uri": aat_uri,
+            "prefLabel": self._extract_value(binding, "prefLabel"),
+            "scopeNote": self._extract_value(binding, "scopeNote"),
+            "broader": (
+                {
+                    "uri": self._extract_value(binding, "broader"),
+                    "label": self._extract_value(binding, "broaderLabel"),
+                }
+                if self._extract_value(binding, "broader")
+                else None
+            ),
+        }
+
+    def lookup_getty_materials(self, material_uris: List[str]) -> List[Dict[str, Any]]:
+        """
+        Lookup multiple Getty AAT material terms.
+
+        Args:
+            material_uris: List of Getty AAT URIs
+
+        Returns:
+            List of term dictionaries
+        """
+        return [self.get_getty_term(uri) for uri in material_uris]
+
+    # =========================================================================
+    # Combined Enrichment
+    # =========================================================================
+
+    def enrich_from_local_uris(
+        self,
+        dbpedia_uri: Optional[str] = None,
+        wikidata_uri: Optional[str] = None,
+        getty_uris: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Enrich data from external sources based on provided URIs.
+
+        Args:
+            dbpedia_uri: DBpedia resource URI
+            wikidata_uri: Wikidata entity URI
+            getty_uris: List of Getty AAT URIs
+
+        Returns:
+            Combined enrichment data from all sources
+        """
+        enrichment = {
+            "dbpedia": None,
+            "wikidata": None,
+            "getty": [],
+        }
+
+        if dbpedia_uri:
+            enrichment["dbpedia"] = self.get_dbpedia_artwork_info(dbpedia_uri)
+
+        if wikidata_uri:
+            enrichment["wikidata"] = self.get_wikidata_artwork_info(wikidata_uri)
+
+        if getty_uris:
+            enrichment["getty"] = self.lookup_getty_materials(getty_uris)
+
+        return enrichment
+
+
+# Singleton instance
+external_sparql_service = ExternalSPARQLService()

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,6 +11,7 @@ info:
     - Full-text search with faceted filtering
     - Artwork recommendations
     - QR code generation for artwork identification
+    - **External SPARQL Integration**: Query DBpedia, Wikidata, and Getty AAT for enriched artwork metadata
   version: 1.0.0
   contact:
     name: ArP Development Team
@@ -37,6 +38,8 @@ tags:
     description: Artwork recommendations
   - name: qr
     description: QR code generation
+  - name: external
+    description: External SPARQL integration (DBpedia, Wikidata, Getty AAT)
 
 paths:
   # ============================================
@@ -439,6 +442,171 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  # ============================================
+  # EXTERNAL SPARQL INTEGRATION
+  # ============================================
+  /artworks/{id}/enrich:
+    parameters:
+      - $ref: '#/components/parameters/ArtworkId'
+
+    get:
+      tags: [external]
+      summary: Enrich artwork with external data
+      description: |
+        Fetch and combine external data for an artwork from DBpedia, Wikidata, and Getty AAT.
+        
+        This endpoint:
+        1. Queries the local Fuseki triplestore for owl:sameAs links
+        2. Fetches data from each linked external source
+        3. Returns combined enrichment data including artist information
+        
+        Results are cached for performance.
+      operationId: enrichArtwork
+      responses:
+        '200':
+          description: Enrichment data retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtworkEnrichment'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /external/dbpedia/artwork/{resource}:
+    get:
+      tags: [external]
+      summary: Query DBpedia for artwork information
+      description: Fetch artwork metadata from DBpedia including abstract, thumbnail, artist, and museum information.
+      operationId: getDbpediaArtwork
+      parameters:
+        - name: resource
+          in: path
+          required: true
+          description: "DBpedia resource name or full URI (e.g., 'Mona_Lisa')"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: DBpedia data retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalQueryResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /external/dbpedia/artist/{resource}:
+    get:
+      tags: [external]
+      summary: Query DBpedia for artist information
+      description: Fetch artist biographical data from DBpedia including birth/death dates, nationality, and art movement.
+      operationId: getDbpediaArtist
+      parameters:
+        - name: resource
+          in: path
+          required: true
+          description: "DBpedia resource name or full URI (e.g., 'Leonardo_da_Vinci')"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: DBpedia artist data retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalQueryResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /external/wikidata/artwork/{entity}:
+    get:
+      tags: [external]
+      summary: Query Wikidata for artwork information
+      description: Fetch artwork metadata from Wikidata including image, inception date, materials, and location.
+      operationId: getWikidataArtwork
+      parameters:
+        - name: entity
+          in: path
+          required: true
+          description: "Wikidata Q-ID or full URI (e.g., 'Q12418')"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Wikidata data retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalQueryResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /external/wikidata/artist/{entity}:
+    get:
+      tags: [external]
+      summary: Query Wikidata for artist information
+      description: Fetch artist biographical data from Wikidata including birth/death dates, nationality, and occupation.
+      operationId: getWikidataArtist
+      parameters:
+        - name: entity
+          in: path
+          required: true
+          description: "Wikidata Q-ID or full URI (e.g., 'Q762' for Leonardo da Vinci)"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Wikidata artist data retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalQueryResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /external/getty/{aat_id}:
+    get:
+      tags: [external]
+      summary: Query Getty AAT for term information
+      description: Fetch term information from Getty Art & Architecture Thesaurus including preferred label and scope note.
+      operationId: getGettyTerm
+      parameters:
+        - name: aat_id
+          in: path
+          required: true
+          description: "Getty AAT ID (e.g., '300015050' for oil paint)"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Getty AAT term retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalQueryResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /external/cache/clear:
+    post:
+      tags: [external]
+      summary: Clear external query cache
+      description: Clear all cached external query results.
+      operationId: clearCache
+      responses:
+        '200':
+          description: Cache cleared successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Cache cleared successfully"
+
 # ============================================
 # COMPONENTS
 # ============================================
@@ -813,6 +981,134 @@ components:
           type: string
         count:
           type: integer
+
+    # ----------------------------------------
+    # External Integration Schemas
+    # ----------------------------------------
+    LinkedEntity:
+      type: object
+      description: A linked entity with URI and label
+      properties:
+        uri:
+          type: string
+          format: uri
+          description: Entity URI
+        label:
+          type: string
+          description: Human-readable label
+
+    ExternalQueryResponse:
+      type: object
+      description: Generic response for external SPARQL queries
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          additionalProperties: true
+        error:
+          type: string
+        source:
+          type: string
+          enum: [dbpedia, wikidata, getty]
+
+    DBpediaInfo:
+      type: object
+      description: Information retrieved from DBpedia
+      properties:
+        source:
+          type: string
+          example: "dbpedia"
+        uri:
+          type: string
+          format: uri
+        abstract:
+          type: string
+          description: English abstract from DBpedia
+        thumbnail:
+          type: string
+          format: uri
+          description: Thumbnail image URL
+        artist:
+          $ref: '#/components/schemas/LinkedEntity'
+        museum:
+          $ref: '#/components/schemas/LinkedEntity'
+        wikidata_uri:
+          type: string
+          format: uri
+
+    WikidataInfo:
+      type: object
+      description: Information retrieved from Wikidata
+      properties:
+        source:
+          type: string
+          example: "wikidata"
+        uri:
+          type: string
+          format: uri
+        qid:
+          type: string
+          description: Wikidata Q-ID
+          example: "Q12418"
+        image:
+          type: string
+          format: uri
+        inception:
+          type: string
+          description: Date of creation
+        creator:
+          $ref: '#/components/schemas/LinkedEntity'
+        location:
+          $ref: '#/components/schemas/LinkedEntity'
+        material:
+          $ref: '#/components/schemas/LinkedEntity'
+        genre:
+          $ref: '#/components/schemas/LinkedEntity'
+        movement:
+          $ref: '#/components/schemas/LinkedEntity'
+
+    GettyTerm:
+      type: object
+      description: Getty AAT term information
+      properties:
+        source:
+          type: string
+          example: "getty"
+        uri:
+          type: string
+          format: uri
+        prefLabel:
+          type: string
+          description: Preferred label in English
+          example: "oil paint"
+        scopeNote:
+          type: string
+          description: Definition or scope note
+        broader:
+          $ref: '#/components/schemas/LinkedEntity'
+
+    ArtworkEnrichment:
+      type: object
+      description: Combined enrichment data from external sources
+      required: [artwork_id]
+      properties:
+        artwork_id:
+          type: string
+          description: The artwork identifier
+          example: "artwork_mona_lisa"
+        dbpedia:
+          $ref: '#/components/schemas/DBpediaInfo'
+        wikidata:
+          $ref: '#/components/schemas/WikidataInfo'
+        getty:
+          type: array
+          items:
+            $ref: '#/components/schemas/GettyTerm'
+        artist_dbpedia:
+          $ref: '#/components/schemas/DBpediaInfo'
+        artist_wikidata:
+          $ref: '#/components/schemas/WikidataInfo'
 
     # ----------------------------------------
     # Error Schemas


### PR DESCRIPTION
…y AAT

- Add ExternalSPARQLService with clients for DBpedia, Wikidata, and Getty AAT
- Implement TTL-based in-memory caching (1 hour default) for external queries
- Create /api/external/* endpoints for direct external source queries
- Add /api/artworks/{id}/enrich endpoint for combined enrichment
- Add Pydantic models for external data (LinkedEntity, ArtworkEnrichment, etc.)
- Update config with external endpoint URLs and cache settings
- Add CORS middleware for frontend access
- Update OpenAPI spec with external integration documentation

External queries fetch:
- DBpedia: abstracts, thumbnails, artist bios
- Wikidata: images, inception dates, materials, locations
- Getty AAT: art terminology labels and scope notes

Closes #8