### PR TITLE
fix: resolve UI issues with artworks display and improve performance

### DIFF
--- a/backend/app/models/artwork.py
+++ b/backend/app/models/artwork.py
@@ -39,10 +39,21 @@ class ArtworkUpdate(BaseModel):
     style: Optional[str] = None
 
 
+class ExternalLinks(BaseModel):
+    """External links to DBpedia, Wikidata, Getty AAT."""
+    
+    dbpedia: Optional[str] = None
+    wikidata: Optional[str] = None
+    getty: Optional[str] = None
+
+
 class ArtworkResponse(ArtworkBase):
     """Schema for artwork response with JSON-LD context."""
     
     id: str
+    
+    # External links from owl:sameAs
+    externalLinks: Optional[ExternalLinks] = None
     
     # JSON-LD context
     context: Optional[Dict[str, Any]] = Field(None, alias="@context")

--- a/backend/app/models/external.py
+++ b/backend/app/models/external.py
@@ -80,6 +80,17 @@ class GettyTerm(BaseModel):
     error: Optional[str] = None
 
 
+class LocalArtistInfo(BaseModel):
+    """Artist information from local triplestore."""
+    source: str = "local"
+    uri: Optional[str] = None
+    name: Optional[str] = None
+    birthDate: Optional[str] = None
+    deathDate: Optional[str] = None
+    nationality: Optional[str] = None
+    description: Optional[str] = None
+
+
 class ExternalLinks(BaseModel):
     """External links for an artwork or artist."""
     dbpedia: Optional[str] = Field(None, description="DBpedia resource URI")
@@ -95,6 +106,7 @@ class ArtworkEnrichment(BaseModel):
     getty: Optional[List[GettyTerm]] = None
     artist_dbpedia: Optional[DBpediaArtistInfo] = None
     artist_wikidata: Optional[WikidataArtistInfo] = None
+    artist_local: Optional[LocalArtistInfo] = None
     
     class Config:
         json_schema_extra = {

--- a/backend/app/services/artwork_service.py
+++ b/backend/app/services/artwork_service.py
@@ -1,12 +1,16 @@
 """Artwork service for RDF/SPARQL operations."""
 
 import uuid
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
 
-from ..models.artwork import ArtworkCreate, ArtworkResponse, ArtworkListResponse
+from ..models.artwork import (
+    ArtworkCreate,
+    ArtworkListResponse,
+    ArtworkResponse,
+    ExternalLinks,
+)
 from ..models.provenance import ProvenanceRecord
 from .sparql_service import sparql_service
-
 
 # RDF Namespaces and JSON-LD context
 # Match the namespace used in fuseki/data/*.ttl files
@@ -15,6 +19,7 @@ DC_NS = "http://purl.org/dc/elements/1.1/"
 DCTERMS_NS = "http://purl.org/dc/terms/"
 PROV_NS = "http://www.w3.org/ns/prov#"
 SCHEMA_NS = "http://schema.org/"
+OWL_NS = "http://www.w3.org/2002/07/owl#"
 
 JSONLD_CONTEXT = {
     "@vocab": ARP_NS,
@@ -31,56 +36,62 @@ JSONLD_CONTEXT = {
     "currentLocation": "arp:currentLocation",
     "period": "arp:artworkPeriod",
     "style": "arp:artworkStyle",
-    "imageUrl": "schema:image"
+    "imageUrl": "schema:image",
 }
 
 
 class ArtworkService:
     """Service for artwork CRUD operations using SPARQL."""
-    
+
     def _generate_id(self) -> str:
         """Generate a unique artwork ID."""
         return f"artwork_{uuid.uuid4().hex[:12]}"
-    
+
     def _uri_to_id(self, uri: str) -> str:
         """Extract ID from full URI."""
         if uri.startswith(ARP_NS):
             return uri.replace(ARP_NS, "")
         return uri
-    
+
     def _id_to_uri(self, id: str) -> str:
         """Convert ID to full URI."""
         return f"{ARP_NS}{id}" if not id.startswith("http") else id
-    
+
     def _escape_literal(self, value: str) -> str:
         """Escape special characters in SPARQL literals."""
         if value is None:
             return ""
         return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
-    
+
     def list_artworks(
         self,
         page: int = 1,
         limit: int = 20,
         artist: Optional[str] = None,
         period: Optional[str] = None,
-        search: Optional[str] = None
+        search: Optional[str] = None,
     ) -> ArtworkListResponse:
         """List artworks with pagination and optional filters."""
         offset = (page - 1) * limit
-        
+
         # Build filter clauses
         filters = []
         if artist:
-            filters.append(f'FILTER(CONTAINS(LCASE(?artist), LCASE("{self._escape_literal(artist)}")))')
+            filters.append(
+                f'FILTER(CONTAINS(LCASE(?artist), LCASE("{self._escape_literal(artist)}")))'
+            )
         if period:
-            filters.append(f'FILTER(CONTAINS(LCASE(?period), LCASE("{self._escape_literal(period)}")))')
+            filters.append(
+                f'FILTER(CONTAINS(LCASE(?period), LCASE("{self._escape_literal(period)}")))'
+            )
         if search:
-            filters.append(f'FILTER(CONTAINS(LCASE(?title), LCASE("{self._escape_literal(search)}")) || CONTAINS(LCASE(?description), LCASE("{self._escape_literal(search)}")))')
-        
+            filters.append(
+                f'FILTER(CONTAINS(LCASE(?title), LCASE("{self._escape_literal(search)}")) || CONTAINS(LCASE(?description), LCASE("{self._escape_literal(search)}")))'
+            )
+
         filter_clause = "\n".join(filters)
-        
-        # Count query
+
+        # Count query - count unique artworks (prefer English titles to match main query)
         count_query = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
@@ -90,17 +101,26 @@ class ArtworkService:
         SELECT (COUNT(DISTINCT ?artwork) AS ?total) WHERE {{
             ?artwork a arp:Artwork .
             ?artwork dc:title ?title .
+            # Prefer English title, fallback to any title if no English version exists
+            FILTER(LANG(?title) = "en" || NOT EXISTS {{ ?artwork dc:title ?enTitle . FILTER(LANG(?enTitle) = "en") }})
             OPTIONAL {{ ?artwork dc:creator ?artistUri . ?artistUri schema:name ?artist }}
             OPTIONAL {{ ?artwork arp:artworkPeriod ?period }}
-            OPTIONAL {{ ?artwork dc:description ?description }}
+            OPTIONAL {{ 
+                ?artwork dc:description ?description .
+                FILTER(LANG(?description) = "en" || LANG(?description) = "" || NOT EXISTS {{ ?artwork dc:description ?enDesc . FILTER(LANG(?enDesc) = "en") }})
+            }}
             {filter_clause}
         }}
         """
-        
+
         count_result = sparql_service.execute_query(count_query)
-        total = int(count_result["results"]["bindings"][0]["total"]["value"]) if count_result["results"]["bindings"] else 0
-        
-        # Main query
+        total = (
+            int(count_result["results"]["bindings"][0]["total"]["value"])
+            if count_result["results"]["bindings"]
+            else 0
+        )
+
+        # Main query - prefer English titles to avoid duplicates from multi-language titles
         query = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
@@ -112,11 +132,16 @@ class ArtworkService:
         WHERE {{
             ?artwork a arp:Artwork .
             ?artwork dc:title ?title .
+            # Prefer English title, fallback to any title if no English version exists
+            FILTER(LANG(?title) = "en" || NOT EXISTS {{ ?artwork dc:title ?enTitle . FILTER(LANG(?enTitle) = "en") }})
             OPTIONAL {{ ?artwork dc:creator ?artistUri . ?artistUri schema:name ?artist }}
             OPTIONAL {{ ?artwork dcterms:created ?dateCreated }}
             OPTIONAL {{ ?artwork arp:artworkMedium ?medium }}
             OPTIONAL {{ ?artwork arp:artworkDimensions ?dimensions }}
-            OPTIONAL {{ ?artwork dc:description ?description }}
+            OPTIONAL {{ 
+                ?artwork dc:description ?description .
+                FILTER(LANG(?description) = "en" || LANG(?description) = "" || NOT EXISTS {{ ?artwork dc:description ?enDesc . FILTER(LANG(?enDesc) = "en") }})
+            }}
             OPTIONAL {{ ?artwork schema:image ?imageUrl }}
             OPTIONAL {{ ?artwork arp:currentLocation ?locUri . ?locUri schema:name ?currentLocation }}
             OPTIONAL {{ ?artwork arp:artworkPeriod ?period }}
@@ -127,9 +152,9 @@ class ArtworkService:
         LIMIT {limit}
         OFFSET {offset}
         """
-        
+
         result = sparql_service.execute_query(query)
-        
+
         items = []
         for binding in result["results"]["bindings"]:
             artwork = ArtworkResponse(
@@ -146,50 +171,81 @@ class ArtworkService:
                 style=binding.get("style", {}).get("value"),
             )
             items.append(artwork)
-        
+
         return ArtworkListResponse(
             items=items,
             total=total,
             page=page,
             limit=limit,
             hasMore=(page * limit) < total,
-            context=JSONLD_CONTEXT
+            context=JSONLD_CONTEXT,
         )
-    
+
     def get_artwork(self, artwork_id: str) -> Optional[ArtworkResponse]:
         """Get a single artwork by ID."""
         uri = self._id_to_uri(artwork_id)
-        
+
         query = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
         PREFIX arp: <{ARP_NS}>
         PREFIX schema: <{SCHEMA_NS}>
+        PREFIX owl: <{OWL_NS}>
         
         SELECT ?title ?artist ?dateCreated ?medium ?dimensions 
-               ?description ?imageUrl ?currentLocation ?period ?style
+               ?description ?imageUrl ?currentLocation ?period ?style ?sameAs ?artMedium
         WHERE {{
             <{uri}> a arp:Artwork .
             <{uri}> dc:title ?title .
+            # Prefer English title
+            FILTER(LANG(?title) = "en" || NOT EXISTS {{ <{uri}> dc:title ?enTitle . FILTER(LANG(?enTitle) = "en") }})
             OPTIONAL {{ <{uri}> dc:creator ?artistUri . ?artistUri schema:name ?artist }}
             OPTIONAL {{ <{uri}> dcterms:created ?dateCreated }}
             OPTIONAL {{ <{uri}> arp:artworkMedium ?medium }}
             OPTIONAL {{ <{uri}> arp:artworkDimensions ?dimensions }}
-            OPTIONAL {{ <{uri}> dc:description ?description }}
+            OPTIONAL {{ 
+                <{uri}> dc:description ?description .
+                FILTER(LANG(?description) = "en" || LANG(?description) = "" || NOT EXISTS {{ <{uri}> dc:description ?enDesc . FILTER(LANG(?enDesc) = "en") }})
+            }}
             OPTIONAL {{ <{uri}> schema:image ?imageUrl }}
             OPTIONAL {{ <{uri}> arp:currentLocation ?locUri . ?locUri schema:name ?currentLocation }}
             OPTIONAL {{ <{uri}> arp:artworkPeriod ?period }}
             OPTIONAL {{ <{uri}> arp:artworkStyle ?style }}
+            OPTIONAL {{ <{uri}> owl:sameAs ?sameAs }}
+            OPTIONAL {{ <{uri}> schema:artMedium ?artMedium }}
         }}
         """
-        
+
         result = sparql_service.execute_query(query)
-        
+
         if not result["results"]["bindings"]:
             return None
-        
+
         binding = result["results"]["bindings"][0]
-        
+
+        # Extract external links from all bindings (owl:sameAs may have multiple values)
+        dbpedia_uri = None
+        wikidata_uri = None
+        getty_uri = None
+
+        for b in result["results"]["bindings"]:
+            same_as = b.get("sameAs", {}).get("value", "")
+            if "dbpedia.org" in same_as and not dbpedia_uri:
+                dbpedia_uri = same_as
+            elif "wikidata.org" in same_as and not wikidata_uri:
+                wikidata_uri = same_as
+
+            art_medium = b.get("artMedium", {}).get("value", "")
+            if "vocab.getty.edu" in art_medium and not getty_uri:
+                getty_uri = art_medium
+
+        # Build external links if any found
+        external_links = None
+        if dbpedia_uri or wikidata_uri or getty_uri:
+            external_links = ExternalLinks(
+                dbpedia=dbpedia_uri, wikidata=wikidata_uri, getty=getty_uri
+            )
+
         return ArtworkResponse(
             id=artwork_id,
             title=binding["title"]["value"],
@@ -202,41 +258,58 @@ class ArtworkService:
             currentLocation=binding.get("currentLocation", {}).get("value"),
             period=binding.get("period", {}).get("value"),
             style=binding.get("style", {}).get("value"),
+            externalLinks=external_links,
             context=JSONLD_CONTEXT,
-            type="Artwork"
+            type="Artwork",
         )
-    
+
     def create_artwork(self, data: ArtworkCreate) -> ArtworkResponse:
         """Create a new artwork in Fuseki."""
         artwork_id = self._generate_id()
         uri = self._id_to_uri(artwork_id)
-        
+
         triples = [
-            f'<{uri}> a arp:Artwork',
-            f'<{uri}> dc:title "{self._escape_literal(data.title)}"'
+            f"<{uri}> a arp:Artwork",
+            f'<{uri}> dc:title "{self._escape_literal(data.title)}"',
         ]
-        
+
         if data.artist:
-            triples.append(f'<{uri}> arp:artistName "{self._escape_literal(data.artist)}"')
+            triples.append(
+                f'<{uri}> arp:artistName "{self._escape_literal(data.artist)}"'
+            )
         if data.dateCreated:
-            triples.append(f'<{uri}> dcterms:created "{self._escape_literal(data.dateCreated)}"')
+            triples.append(
+                f'<{uri}> dcterms:created "{self._escape_literal(data.dateCreated)}"'
+            )
         if data.medium:
-            triples.append(f'<{uri}> arp:artworkMedium "{self._escape_literal(data.medium)}"')
+            triples.append(
+                f'<{uri}> arp:artworkMedium "{self._escape_literal(data.medium)}"'
+            )
         if data.dimensions:
-            triples.append(f'<{uri}> arp:artworkDimensions "{self._escape_literal(data.dimensions)}"')
+            triples.append(
+                f'<{uri}> arp:artworkDimensions "{self._escape_literal(data.dimensions)}"'
+            )
         if data.description:
-            triples.append(f'<{uri}> dc:description "{self._escape_literal(data.description)}"')
+            triples.append(
+                f'<{uri}> dc:description "{self._escape_literal(data.description)}"'
+            )
         if data.imageUrl:
-            triples.append(f'<{uri}> schema:image <{data.imageUrl}>')
+            triples.append(f"<{uri}> schema:image <{data.imageUrl}>")
         if data.currentLocation:
-            triples.append(f'<{uri}> arp:currentLocationName "{self._escape_literal(data.currentLocation)}"')
+            triples.append(
+                f'<{uri}> arp:currentLocationName "{self._escape_literal(data.currentLocation)}"'
+            )
         if data.period:
-            triples.append(f'<{uri}> arp:artworkPeriod "{self._escape_literal(data.period)}"')
+            triples.append(
+                f'<{uri}> arp:artworkPeriod "{self._escape_literal(data.period)}"'
+            )
         if data.style:
-            triples.append(f'<{uri}> arp:artworkStyle "{self._escape_literal(data.style)}"')
-        
+            triples.append(
+                f'<{uri}> arp:artworkStyle "{self._escape_literal(data.style)}"'
+            )
+
         triples_str = " .\n    ".join(triples)
-        
+
         update = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
@@ -247,9 +320,9 @@ class ArtworkService:
             {triples_str} .
         }}
         """
-        
+
         sparql_service.execute_update(update)
-        
+
         return ArtworkResponse(
             id=artwork_id,
             title=data.title,
@@ -263,13 +336,13 @@ class ArtworkService:
             period=data.period,
             style=data.style,
             context=JSONLD_CONTEXT,
-            type="Artwork"
+            type="Artwork",
         )
-    
+
     def get_provenance(self, artwork_id: str) -> List[ProvenanceRecord]:
         """Get provenance history for an artwork."""
         artwork_uri = self._id_to_uri(artwork_id)
-        
+
         query = f"""
         PREFIX arp: <{ARP_NS}>
         PREFIX prov: <{PROV_NS}>
@@ -290,9 +363,9 @@ class ArtworkService:
         }}
         ORDER BY ?order ?date
         """
-        
+
         result = sparql_service.execute_query(query)
-        
+
         events = []
         for binding in result["results"]["bindings"]:
             event = ProvenanceRecord(
@@ -303,48 +376,54 @@ class ArtworkService:
                 location=binding.get("location", {}).get("value"),
                 description=binding.get("description", {}).get("value"),
                 sourceUri=binding.get("sourceUri", {}).get("value"),
-                order=int(binding["order"]["value"]) if "order" in binding else None
+                order=int(binding["order"]["value"]) if "order" in binding else None,
             )
             events.append(event)
-        
+
         return events
-    
-    def update_artwork(self, artwork_id: str, data: 'ArtworkUpdate') -> Optional[ArtworkResponse]:
+
+    def update_artwork(
+        self, artwork_id: str, data: "ArtworkUpdate"
+    ) -> Optional[ArtworkResponse]:
         """Update an existing artwork."""
         existing = self.get_artwork(artwork_id)
         if not existing:
             return None
-        
+
         uri = self._id_to_uri(artwork_id)
-        
+
         delete_triples = []
         insert_triples = []
-        
+
         field_mappings = {
-            'title': ('dc:title', data.title),
-            'artist': ('arp:artistName', data.artist),
-            'dateCreated': ('dcterms:created', data.dateCreated),
-            'medium': ('arp:artworkMedium', data.medium),
-            'dimensions': ('arp:artworkDimensions', data.dimensions),
-            'description': ('dc:description', data.description),
-            'imageUrl': ('schema:image', data.imageUrl),
-            'currentLocation': ('arp:currentLocationName', data.currentLocation),
-            'period': ('arp:artworkPeriod', data.period),
-            'style': ('arp:artworkStyle', data.style),
+            "title": ("dc:title", data.title),
+            "artist": ("arp:artistName", data.artist),
+            "dateCreated": ("dcterms:created", data.dateCreated),
+            "medium": ("arp:artworkMedium", data.medium),
+            "dimensions": ("arp:artworkDimensions", data.dimensions),
+            "description": ("dc:description", data.description),
+            "imageUrl": ("schema:image", data.imageUrl),
+            "currentLocation": ("arp:currentLocationName", data.currentLocation),
+            "period": ("arp:artworkPeriod", data.period),
+            "style": ("arp:artworkStyle", data.style),
         }
-        
+
         for field, (predicate, value) in field_mappings.items():
             if value is not None:
-                delete_triples.append(f'<{uri}> {predicate} ?old_{field}')
-                insert_triples.append(f'<{uri}> {predicate} "{self._escape_literal(value)}"')
-        
+                delete_triples.append(f"<{uri}> {predicate} ?old_{field}")
+                insert_triples.append(
+                    f'<{uri}> {predicate} "{self._escape_literal(value)}"'
+                )
+
         if not insert_triples:
             return existing
-        
+
         delete_clause = " .\n        ".join(delete_triples)
         insert_clause = " .\n        ".join(insert_triples)
-        optional_clauses = "\n        ".join([f'OPTIONAL {{ {t} }}' for t in delete_triples])
-        
+        optional_clauses = "\n        ".join(
+            [f"OPTIONAL {{ {t} }}" for t in delete_triples]
+        )
+
         update = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
@@ -362,18 +441,18 @@ class ArtworkService:
             {optional_clauses}
         }}
         """
-        
+
         sparql_service.execute_update(update)
         return self.get_artwork(artwork_id)
-    
+
     def delete_artwork(self, artwork_id: str) -> bool:
         """Delete an artwork and its provenance."""
         uri = self._id_to_uri(artwork_id)
-        
+
         existing = self.get_artwork(artwork_id)
         if not existing:
             return False
-        
+
         update = f"""
         PREFIX arp: <{ARP_NS}>
         
@@ -389,18 +468,20 @@ class ArtworkService:
             }}
         }}
         """
-        
+
         sparql_service.execute_update(update)
         return True
-    
-    def add_provenance_event(self, artwork_id: str, data: 'ProvenanceEventCreate') -> ProvenanceRecord:
+
+    def add_provenance_event(
+        self, artwork_id: str, data: "ProvenanceEventCreate"
+    ) -> ProvenanceRecord:
         """Add a provenance event to an artwork."""
         from ..models.provenance import ProvenanceEventCreate
-        
+
         artwork_uri = self._id_to_uri(artwork_id)
         event_id = f"provenance_{uuid.uuid4().hex[:12]}"
         event_uri = f"{ARP_NS}{event_id}"
-        
+
         order_query = f"""
         PREFIX arp: <{ARP_NS}>
         
@@ -412,30 +493,40 @@ class ArtworkService:
         order_result = sparql_service.execute_query(order_query)
         max_order = 0
         if order_result["results"]["bindings"]:
-            max_val = order_result["results"]["bindings"][0].get("maxOrder", {}).get("value")
+            max_val = (
+                order_result["results"]["bindings"][0].get("maxOrder", {}).get("value")
+            )
             if max_val:
                 max_order = int(max_val)
         new_order = max_order + 1
-        
+
         triples = [
-            f'<{artwork_uri}> arp:hasProvenanceEvent <{event_uri}>',
-            f'<{event_uri}> a arp:ProvenanceEvent',
+            f"<{artwork_uri}> arp:hasProvenanceEvent <{event_uri}>",
+            f"<{event_uri}> a arp:ProvenanceEvent",
             f'<{event_uri}> arp:eventType "{self._escape_literal(data.event.value)}"',
             f'<{event_uri}> prov:startedAtTime "{self._escape_literal(data.date)}"',
-            f'<{event_uri}> arp:provenanceOrder {new_order}',
+            f"<{event_uri}> arp:provenanceOrder {new_order}",
         ]
-        
+
         if data.owner:
-            triples.append(f'<{event_uri}> arp:owner "{self._escape_literal(data.owner)}"')
+            triples.append(
+                f'<{event_uri}> arp:owner "{self._escape_literal(data.owner)}"'
+            )
         if data.location:
-            triples.append(f'<{event_uri}> arp:location "{self._escape_literal(data.location)}"')
+            triples.append(
+                f'<{event_uri}> arp:location "{self._escape_literal(data.location)}"'
+            )
         if data.description:
-            triples.append(f'<{event_uri}> arp:description "{self._escape_literal(data.description)}"')
+            triples.append(
+                f'<{event_uri}> arp:description "{self._escape_literal(data.description)}"'
+            )
         if data.sourceUri:
-            triples.append(f'<{event_uri}> arp:sourceUri "{self._escape_literal(data.sourceUri)}"')
-        
+            triples.append(
+                f'<{event_uri}> arp:sourceUri "{self._escape_literal(data.sourceUri)}"'
+            )
+
         triples_str = " .\n        ".join(triples)
-        
+
         update = f"""
         PREFIX arp: <{ARP_NS}>
         PREFIX prov: <{PROV_NS}>
@@ -444,9 +535,9 @@ class ArtworkService:
             {triples_str} .
         }}
         """
-        
+
         sparql_service.execute_update(update)
-        
+
         return ProvenanceRecord(
             id=event_id,
             event=data.event,
@@ -455,15 +546,17 @@ class ArtworkService:
             location=data.location,
             description=data.description,
             sourceUri=data.sourceUri,
-            order=new_order
+            order=new_order,
         )
-    
-    def update_provenance_event(self, artwork_id: str, event_id: str, data: 'ProvenanceEventUpdate') -> Optional[ProvenanceRecord]:
+
+    def update_provenance_event(
+        self, artwork_id: str, event_id: str, data: "ProvenanceEventUpdate"
+    ) -> Optional[ProvenanceRecord]:
         """Update a provenance event."""
         from ..models.provenance import ProvenanceEventUpdate
-        
+
         event_uri = self._id_to_uri(event_id)
-        
+
         check_query = f"""
         PREFIX arp: <{ARP_NS}>
         
@@ -475,37 +568,51 @@ class ArtworkService:
                 return None
         except:
             return None
-        
+
         delete_triples = []
         insert_triples = []
-        
+
         if data.event is not None:
-            delete_triples.append(f'<{event_uri}> arp:eventType ?oldEventType')
-            insert_triples.append(f'<{event_uri}> arp:eventType "{self._escape_literal(data.event.value)}"')
+            delete_triples.append(f"<{event_uri}> arp:eventType ?oldEventType")
+            insert_triples.append(
+                f'<{event_uri}> arp:eventType "{self._escape_literal(data.event.value)}"'
+            )
         if data.date is not None:
-            delete_triples.append(f'<{event_uri}> prov:startedAtTime ?oldDate')
-            insert_triples.append(f'<{event_uri}> prov:startedAtTime "{self._escape_literal(data.date)}"')
+            delete_triples.append(f"<{event_uri}> prov:startedAtTime ?oldDate")
+            insert_triples.append(
+                f'<{event_uri}> prov:startedAtTime "{self._escape_literal(data.date)}"'
+            )
         if data.owner is not None:
-            delete_triples.append(f'<{event_uri}> arp:owner ?oldOwner')
-            insert_triples.append(f'<{event_uri}> arp:owner "{self._escape_literal(data.owner)}"')
+            delete_triples.append(f"<{event_uri}> arp:owner ?oldOwner")
+            insert_triples.append(
+                f'<{event_uri}> arp:owner "{self._escape_literal(data.owner)}"'
+            )
         if data.location is not None:
-            delete_triples.append(f'<{event_uri}> arp:location ?oldLocation')
-            insert_triples.append(f'<{event_uri}> arp:location "{self._escape_literal(data.location)}"')
+            delete_triples.append(f"<{event_uri}> arp:location ?oldLocation")
+            insert_triples.append(
+                f'<{event_uri}> arp:location "{self._escape_literal(data.location)}"'
+            )
         if data.description is not None:
-            delete_triples.append(f'<{event_uri}> arp:description ?oldDescription')
-            insert_triples.append(f'<{event_uri}> arp:description "{self._escape_literal(data.description)}"')
+            delete_triples.append(f"<{event_uri}> arp:description ?oldDescription")
+            insert_triples.append(
+                f'<{event_uri}> arp:description "{self._escape_literal(data.description)}"'
+            )
         if data.sourceUri is not None:
-            delete_triples.append(f'<{event_uri}> arp:sourceUri ?oldSourceUri')
-            insert_triples.append(f'<{event_uri}> arp:sourceUri "{self._escape_literal(data.sourceUri)}"')
-        
+            delete_triples.append(f"<{event_uri}> arp:sourceUri ?oldSourceUri")
+            insert_triples.append(
+                f'<{event_uri}> arp:sourceUri "{self._escape_literal(data.sourceUri)}"'
+            )
+
         if not insert_triples:
             events = self.get_provenance(artwork_id)
             return next((e for e in events if e.id == event_id), None)
-        
+
         delete_clause = " .\n        ".join(delete_triples)
         insert_clause = " .\n        ".join(insert_triples)
-        optional_clauses = "\n        ".join([f'OPTIONAL {{ {t} }}' for t in delete_triples])
-        
+        optional_clauses = "\n        ".join(
+            [f"OPTIONAL {{ {t} }}" for t in delete_triples]
+        )
+
         update = f"""
         PREFIX arp: <{ARP_NS}>
         PREFIX prov: <{PROV_NS}>
@@ -521,17 +628,17 @@ class ArtworkService:
             {optional_clauses}
         }}
         """
-        
+
         sparql_service.execute_update(update)
-        
+
         events = self.get_provenance(artwork_id)
         return next((e for e in events if e.id == event_id), None)
-    
+
     def delete_provenance_event(self, artwork_id: str, event_id: str) -> bool:
         """Delete a provenance event."""
         artwork_uri = self._id_to_uri(artwork_id)
         event_uri = self._id_to_uri(event_id)
-        
+
         update = f"""
         PREFIX arp: <{ARP_NS}>
         
@@ -544,40 +651,40 @@ class ArtworkService:
             <{event_uri}> ?p ?o .
         }}
         """
-        
+
         sparql_service.execute_update(update)
         return True
-    
+
     def search_artworks(
-        self,
-        q: str,
-        fields: Optional[List[str]] = None,
-        page: int = 1,
-        limit: int = 20
+        self, q: str, fields: Optional[List[str]] = None, page: int = 1, limit: int = 20
     ) -> Dict[str, Any]:
         """Full-text search across artworks."""
         offset = (page - 1) * limit
-        
+
         if not fields:
-            fields = ['title', 'artist', 'description']
-        
+            fields = ["title", "artist", "description"]
+
         field_mappings = {
-            'title': '?title',
-            'artist': '?artist',
-            'description': '?description',
+            "title": "?title",
+            "artist": "?artist",
+            "description": "?description",
         }
-        
+
         search_filters = []
         for field in fields:
             if field in field_mappings:
                 var = field_mappings[field]
-                search_filters.append(f'CONTAINS(LCASE({var}), LCASE("{self._escape_literal(q)}"))')
-        
+                search_filters.append(
+                    f'CONTAINS(LCASE({var}), LCASE("{self._escape_literal(q)}"))'
+                )
+
         if not search_filters:
-            search_filters = [f'CONTAINS(LCASE(?title), LCASE("{self._escape_literal(q)}"))']
-        
+            search_filters = [
+                f'CONTAINS(LCASE(?title), LCASE("{self._escape_literal(q)}"))'
+            ]
+
         filter_expression = " || ".join(search_filters)
-        
+
         count_query = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
@@ -587,15 +694,24 @@ class ArtworkService:
         SELECT (COUNT(DISTINCT ?artwork) AS ?total) WHERE {{
             ?artwork a arp:Artwork .
             ?artwork dc:title ?title .
+            # Prefer English title
+            FILTER(LANG(?title) = "en" || NOT EXISTS {{ ?artwork dc:title ?enTitle . FILTER(LANG(?enTitle) = "en") }})
             OPTIONAL {{ ?artwork dc:creator ?artistUri . ?artistUri schema:name ?artist }}
-            OPTIONAL {{ ?artwork dc:description ?description }}
+            OPTIONAL {{ 
+                ?artwork dc:description ?description .
+                FILTER(LANG(?description) = "en" || LANG(?description) = "" || NOT EXISTS {{ ?artwork dc:description ?enDesc . FILTER(LANG(?enDesc) = "en") }})
+            }}
             FILTER({filter_expression})
         }}
         """
-        
+
         count_result = sparql_service.execute_query(count_query)
-        total = int(count_result["results"]["bindings"][0]["total"]["value"]) if count_result["results"]["bindings"] else 0
-        
+        total = (
+            int(count_result["results"]["bindings"][0]["total"]["value"])
+            if count_result["results"]["bindings"]
+            else 0
+        )
+
         query = f"""
         PREFIX dc: <{DC_NS}>
         PREFIX dcterms: <{DCTERMS_NS}>
@@ -607,11 +723,16 @@ class ArtworkService:
         WHERE {{
             ?artwork a arp:Artwork .
             ?artwork dc:title ?title .
+            # Prefer English title
+            FILTER(LANG(?title) = "en" || NOT EXISTS {{ ?artwork dc:title ?enTitle . FILTER(LANG(?enTitle) = "en") }})
             OPTIONAL {{ ?artwork dc:creator ?artistUri . ?artistUri schema:name ?artist }}
             OPTIONAL {{ ?artwork dcterms:created ?dateCreated }}
             OPTIONAL {{ ?artwork arp:artworkMedium ?medium }}
             OPTIONAL {{ ?artwork arp:artworkDimensions ?dimensions }}
-            OPTIONAL {{ ?artwork dc:description ?description }}
+            OPTIONAL {{ 
+                ?artwork dc:description ?description .
+                FILTER(LANG(?description) = "en" || LANG(?description) = "" || NOT EXISTS {{ ?artwork dc:description ?enDesc . FILTER(LANG(?enDesc) = "en") }})
+            }}
             OPTIONAL {{ ?artwork schema:image ?imageUrl }}
             OPTIONAL {{ ?artwork arp:currentLocation ?locUri . ?locUri schema:name ?currentLocation }}
             OPTIONAL {{ ?artwork arp:artworkPeriod ?period }}
@@ -622,9 +743,9 @@ class ArtworkService:
         LIMIT {limit}
         OFFSET {offset}
         """
-        
+
         result = sparql_service.execute_query(query)
-        
+
         items = []
         for binding in result["results"]["bindings"]:
             artwork = {
@@ -641,13 +762,13 @@ class ArtworkService:
                 "style": binding.get("style", {}).get("value"),
             }
             items.append(artwork)
-        
+
         return {
             "query": q,
             "total": total,
             "page": page,
             "limit": limit,
-            "results": items
+            "results": items,
         }
 
 

--- a/backend/app/services/external_sparql_service.py
+++ b/backend/app/services/external_sparql_service.py
@@ -74,22 +74,25 @@ class ExternalSPARQLService:
         """Initialize external SPARQL service with endpoints and cache."""
         self.cache = SimpleCache(ttl=settings.external_cache_ttl)
 
+        # External query timeout (shorter to prevent blocking the API)
+        external_timeout = 10
+
         # Initialize DBpedia client
         self.dbpedia = SPARQLWrapper(settings.dbpedia_endpoint)
         self.dbpedia.setReturnFormat(JSON)
-        self.dbpedia.setTimeout(30)
+        self.dbpedia.setTimeout(external_timeout)
         self.dbpedia.addCustomHttpHeader("User-Agent", "ArP-Artwork-Provenance/1.0")
 
         # Initialize Wikidata client
         self.wikidata = SPARQLWrapper(settings.wikidata_endpoint)
         self.wikidata.setReturnFormat(JSON)
-        self.wikidata.setTimeout(30)
+        self.wikidata.setTimeout(external_timeout)
         self.wikidata.addCustomHttpHeader("User-Agent", "ArP-Artwork-Provenance/1.0")
 
         # Initialize Getty client
         self.getty = SPARQLWrapper(settings.getty_endpoint)
         self.getty.setReturnFormat(JSON)
-        self.getty.setTimeout(30)
+        self.getty.setTimeout(external_timeout)
         self.getty.addCustomHttpHeader("User-Agent", "ArP-Artwork-Provenance/1.0")
 
     def _execute_query(

--- a/backend/app/services/sparql_service.py
+++ b/backend/app/services/sparql_service.py
@@ -8,31 +8,36 @@ from ..config import settings
 
 class SPARQLService:
     """Service for executing SPARQL queries against Fuseki."""
-    
+
+    # Timeout for SPARQL queries in seconds
+    QUERY_TIMEOUT = 15
+
     def __init__(self):
         self.query_endpoint = SPARQLWrapper(settings.fuseki_query_endpoint)
         self.query_endpoint.setReturnFormat(JSON)
-        
+        self.query_endpoint.setTimeout(self.QUERY_TIMEOUT)
+
         self.update_endpoint = SPARQLWrapper(settings.fuseki_update_endpoint)
         self.update_endpoint.setMethod(POST)
         self.update_endpoint.setRequestMethod(POSTDIRECTLY)
+        self.update_endpoint.setTimeout(self.QUERY_TIMEOUT)
         # Fuseki requires authentication for update operations
         self.update_endpoint.setHTTPAuth(BASIC)
         self.update_endpoint.setCredentials(
             settings.fuseki_username, settings.fuseki_password
         )
-    
+
     def execute_query(self, query: str) -> Dict[str, Any]:
         """Execute a SPARQL SELECT query and return results."""
         self.query_endpoint.setQuery(query)
         return self.query_endpoint.query().convert()
-    
+
     def execute_update(self, update: str) -> bool:
         """Execute a SPARQL UPDATE (INSERT/DELETE) query."""
         self.update_endpoint.setQuery(update)
         self.update_endpoint.query()
         return True
-    
+
     def test_connection(self) -> bool:
         """Test if Fuseki is reachable."""
         try:

--- a/frontend/src/components/ArtworkCard.tsx
+++ b/frontend/src/components/ArtworkCard.tsx
@@ -1,0 +1,64 @@
+import { memo, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import type { Artwork } from '../services/api';
+import OptimizedImage, { preloadImage } from './OptimizedImage';
+
+interface ArtworkCardProps {
+  artwork: Artwork;
+  className?: string;
+}
+
+const ArtworkCard = memo(({ artwork, className = '' }: ArtworkCardProps) => {
+  // Preload the higher resolution image on hover for faster detail page load
+  const handleMouseEnter = useCallback(() => {
+    if (artwork.imageUrl) {
+      preloadImage(artwork.imageUrl, 800);
+    }
+  }, [artwork.imageUrl]);
+
+  return (
+    <Link
+      to={`/artworks/${artwork.id}`}
+      className={`group overflow-hidden rounded-2xl border border-bronze/20 bg-ivory shadow-sm transition-all hover:border-gold/40 hover:shadow-lg ${className}`}
+      onMouseEnter={handleMouseEnter}
+    >
+      {/* Image */}
+      <div className="aspect-[4/3] overflow-hidden bg-parchment-dark">
+        <OptimizedImage
+          src={artwork.imageUrl}
+          alt={artwork.title}
+          width={400}
+          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          placeholderClassName="h-full w-full"
+        />
+      </div>
+      
+      {/* Content */}
+      <div className="p-6">
+        <h2 className="font-heading text-xl font-semibold text-charcoal group-hover:text-gold transition-colors line-clamp-2">
+          {artwork.title}
+        </h2>
+        {artwork.artist && (
+          <p className="mt-2 text-charcoal-light">
+            {artwork.artist}
+          </p>
+        )}
+        <div className="mt-4 flex items-center justify-between text-sm text-bronze">
+          <span>{artwork.dateCreated || 'Unknown date'}</span>
+          <span className="truncate ml-2">{artwork.medium || artwork.period}</span>
+        </div>
+        <div className="mt-4 flex items-center gap-2 text-sm text-gold opacity-0 transition-opacity group-hover:opacity-100">
+          <span>View Provenance</span>
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+          </svg>
+        </div>
+      </div>
+    </Link>
+  );
+});
+
+ArtworkCard.displayName = 'ArtworkCard';
+
+export default ArtworkCard;
+

--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'react-router-dom';
+
+interface ErrorMessageProps {
+  title?: string;
+  message: string;
+  onRetry?: () => void;
+  showHomeLink?: boolean;
+  className?: string;
+}
+
+const ErrorMessage = ({ 
+  title = 'Something went wrong', 
+  message, 
+  onRetry, 
+  showHomeLink = false,
+  className = '' 
+}: ErrorMessageProps) => {
+  return (
+    <div className={`rounded-2xl border border-burgundy/20 bg-burgundy/5 p-8 text-center ${className}`}>
+      {/* Error icon */}
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-burgundy/10">
+        <svg 
+          className="h-8 w-8 text-burgundy" 
+          fill="none" 
+          viewBox="0 0 24 24" 
+          stroke="currentColor"
+        >
+          <path 
+            strokeLinecap="round" 
+            strokeLinejoin="round" 
+            strokeWidth={2} 
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" 
+          />
+        </svg>
+      </div>
+      
+      <h3 className="mt-4 font-heading text-xl font-semibold text-charcoal">
+        {title}
+      </h3>
+      
+      <p className="mt-2 text-charcoal-light">
+        {message}
+      </p>
+      
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-gold to-gold-dark px-6 py-3 font-medium text-charcoal shadow-md hover:shadow-lg transition-shadow"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Try Again
+          </button>
+        )}
+        
+        {showHomeLink && (
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 rounded-lg border border-bronze/30 px-6 py-3 font-medium text-charcoal hover:border-gold hover:text-gold transition-colors"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            Go Home
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// 404 Not Found component
+export const NotFound = ({ 
+  itemType = 'page',
+  backLink = '/',
+  backLinkText = 'Go back home'
+}: { 
+  itemType?: string;
+  backLink?: string;
+  backLinkText?: string;
+}) => {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center px-4">
+      <div className="text-center">
+        <h1 className="font-heading text-6xl font-bold text-gold">404</h1>
+        <h2 className="mt-4 font-heading text-2xl font-semibold text-charcoal">
+          {itemType.charAt(0).toUpperCase() + itemType.slice(1)} Not Found
+        </h2>
+        <p className="mt-2 text-charcoal-light">
+          The {itemType} you're looking for doesn't exist or has been moved.
+        </p>
+        <Link
+          to={backLink}
+          className="mt-6 inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-gold to-gold-dark px-6 py-3 font-medium text-charcoal shadow-md hover:shadow-lg transition-shadow"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          {backLinkText}
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorMessage;
+

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -1,0 +1,94 @@
+interface LoadingProps {
+  className?: string;
+}
+
+// Skeleton loader for artwork cards
+export const ArtworkCardSkeleton = ({ className = '' }: LoadingProps) => {
+  return (
+    <div className={`overflow-hidden rounded-2xl border border-bronze/20 bg-ivory shadow-sm ${className}`}>
+      {/* Image skeleton */}
+      <div className="aspect-[4/3] animate-pulse bg-parchment-dark" />
+      
+      {/* Content skeleton */}
+      <div className="p-6">
+        <div className="h-6 w-3/4 animate-pulse rounded bg-parchment-dark" />
+        <div className="mt-2 h-4 w-1/2 animate-pulse rounded bg-parchment-dark" />
+        <div className="mt-4 flex items-center justify-between">
+          <div className="h-4 w-16 animate-pulse rounded bg-parchment-dark" />
+          <div className="h-4 w-20 animate-pulse rounded bg-parchment-dark" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Grid of skeleton cards
+export const ArtworkGridSkeleton = ({ count = 6 }: { count?: number }) => {
+  return (
+    <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: count }).map((_, index) => (
+        <ArtworkCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+};
+
+// Skeleton for artwork detail page
+export const ArtworkDetailSkeleton = () => {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="grid gap-12 lg:grid-cols-2">
+        {/* Image skeleton */}
+        <div className="aspect-square animate-pulse rounded-2xl bg-parchment-dark" />
+        
+        {/* Details skeleton */}
+        <div>
+          <div className="h-10 w-3/4 animate-pulse rounded bg-parchment-dark" />
+          <div className="mt-4 h-6 w-1/3 animate-pulse rounded bg-parchment-dark" />
+          
+          <div className="mt-8 space-y-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="flex border-b border-bronze/10 pb-4">
+                <div className="h-4 w-24 animate-pulse rounded bg-parchment-dark" />
+                <div className="ml-8 h-4 w-48 animate-pulse rounded bg-parchment-dark" />
+              </div>
+            ))}
+          </div>
+          
+          <div className="mt-8">
+            <div className="h-6 w-32 animate-pulse rounded bg-parchment-dark" />
+            <div className="mt-3 space-y-2">
+              <div className="h-4 w-full animate-pulse rounded bg-parchment-dark" />
+              <div className="h-4 w-5/6 animate-pulse rounded bg-parchment-dark" />
+              <div className="h-4 w-4/6 animate-pulse rounded bg-parchment-dark" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Simple spinner
+export const Spinner = ({ className = '' }: LoadingProps) => {
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-bronze/30 border-t-gold" />
+    </div>
+  );
+};
+
+// Full page loading
+export const PageLoading = () => {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <div className="text-center">
+        <Spinner className="mb-4" />
+        <p className="text-charcoal-light">Loading...</p>
+      </div>
+    </div>
+  );
+};
+
+export default Spinner;
+

--- a/frontend/src/components/OptimizedImage.tsx
+++ b/frontend/src/components/OptimizedImage.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, memo, useCallback } from 'react';
+
+// Global cache to track loaded images across components
+const imageCache = new Set<string>();
+
+// Transform Wikimedia Commons URLs to use thumbnails
+const getOptimizedUrl = (url: string, width: number = 400): string => {
+  if (!url) return '';
+  
+  // Handle Wikimedia Commons Special:FilePath URLs
+  if (url.includes('commons.wikimedia.org/wiki/Special:FilePath/')) {
+    const filename = url.split('Special:FilePath/')[1];
+    if (filename) {
+      // Use Wikimedia thumbnail API
+      return `https://commons.wikimedia.org/wiki/Special:FilePath/${filename}?width=${width}`;
+    }
+  }
+  
+  // Handle direct Wikimedia Commons URLs
+  if (url.includes('upload.wikimedia.org/wikipedia/commons/') && !url.includes('/thumb/')) {
+    // Convert to thumbnail URL
+    const match = url.match(/\/wikipedia\/commons\/([a-f0-9])\/([a-f0-9]{2})\/(.+)$/);
+    if (match) {
+      const [, a, ab, filename] = match;
+      return `https://upload.wikimedia.org/wikipedia/commons/thumb/${a}/${ab}/${filename}/${width}px-${filename}`;
+    }
+  }
+  
+  return url;
+};
+
+interface OptimizedImageProps {
+  src: string | undefined;
+  alt: string;
+  className?: string;
+  placeholderClassName?: string;
+  width?: number;
+  property?: string;
+  /** If true, wrapper shrinks to fit image after loading. If false, keeps placeholder dimensions. */
+  shrinkOnLoad?: boolean;
+}
+
+const OptimizedImage = memo(({ 
+  src, 
+  alt, 
+  className = '', 
+  placeholderClassName = '',
+  width = 400,
+  property,
+  shrinkOnLoad = false
+}: OptimizedImageProps) => {
+  const optimizedSrc = src ? getOptimizedUrl(src, width) : '';
+  const [isLoaded, setIsLoaded] = useState(() => imageCache.has(optimizedSrc));
+  const [hasError, setHasError] = useState(false);
+  const [imageSrc, setImageSrc] = useState(optimizedSrc);
+
+  // Placeholder SVG
+  const placeholderImage = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300"%3E%3Crect fill="%23e8e0d0" width="400" height="300"/%3E%3Ctext fill="%238b7355" font-family="sans-serif" font-size="24" x="50%25" y="50%25" text-anchor="middle" dy=".3em"%3ENo Image%3C/text%3E%3C/svg%3E';
+
+  // Reset state when src changes
+  useEffect(() => {
+    const newOptimizedSrc = src ? getOptimizedUrl(src, width) : '';
+    setImageSrc(newOptimizedSrc);
+    setHasError(false);
+    setIsLoaded(imageCache.has(newOptimizedSrc));
+  }, [src, width]);
+
+  const handleLoad = useCallback(() => {
+    if (imageSrc) {
+      imageCache.add(imageSrc);
+    }
+    setIsLoaded(true);
+  }, [imageSrc]);
+
+  const handleError = useCallback(() => {
+    setHasError(true);
+    setIsLoaded(true);
+  }, []);
+
+  // If no src or has error, show placeholder
+  if (!imageSrc || hasError) {
+    return (
+      <img
+        src={placeholderImage}
+        alt={alt}
+        className={className}
+        {...(property && { property })}
+      />
+    );
+  }
+
+  // If shrinkOnLoad is true, remove placeholder sizing after image loads
+  // Otherwise, keep the placeholder class to maintain container sizing (for grid cards)
+  const wrapperClass = (shrinkOnLoad && isLoaded) 
+    ? 'relative' 
+    : `relative ${placeholderClassName}`;
+
+  return (
+    <div className={wrapperClass}>
+      {/* Loading skeleton */}
+      {!isLoaded && (
+        <div className="absolute inset-0 animate-pulse bg-parchment-dark flex items-center justify-center">
+          <svg className="h-12 w-12 text-bronze/30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+        </div>
+      )}
+      <img
+        src={imageSrc}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        className={`${className} ${isLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity duration-300`}
+        onLoad={handleLoad}
+        onError={handleError}
+        {...(property && { property })}
+      />
+    </div>
+  );
+});
+
+OptimizedImage.displayName = 'OptimizedImage';
+
+export default OptimizedImage;
+
+// Export utility for preloading images
+export const preloadImage = (url: string, width: number = 400): void => {
+  const optimizedUrl = getOptimizedUrl(url, width);
+  if (!imageCache.has(optimizedUrl)) {
+    const img = new Image();
+    img.onload = () => imageCache.add(optimizedUrl);
+    img.src = optimizedUrl;
+  }
+};
+

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,3 +1,13 @@
 export { default as Header } from './Header';
 export { default as Footer } from './Footer';
+export { default as ArtworkCard } from './ArtworkCard';
+export { default as ErrorMessage, NotFound } from './ErrorMessage';
+export { default as OptimizedImage, preloadImage } from './OptimizedImage';
+export { 
+  default as Spinner,
+  ArtworkCardSkeleton,
+  ArtworkGridSkeleton,
+  ArtworkDetailSkeleton,
+  PageLoading
+} from './Loading';
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -70,3 +70,18 @@ h1, h2, h3, h4, h5, h6 {
   outline: 2px solid var(--color-gold);
   outline-offset: 2px;
 }
+
+/* Prevent layout shifts from image loading */
+img {
+  content-visibility: auto;
+}
+
+/* Artwork card image container - prevent reflow */
+.aspect-\[4\/3\] {
+  contain: layout;
+}
+
+/* Improve scrolling performance */
+.grid {
+  contain: layout style;
+}

--- a/frontend/src/pages/ArtworkDetailPage.tsx
+++ b/frontend/src/pages/ArtworkDetailPage.tsx
@@ -1,66 +1,243 @@
+import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { artworkApi, type Artwork, type ProvenanceRecord, type ArtworkEnrichment } from '../services/api';
+import { ArtworkDetailSkeleton, ErrorMessage, NotFound, OptimizedImage } from '../components';
 
-// Placeholder data (to be replaced with API call)
-const placeholderArtwork = {
-  id: '1',
-  title: 'The Starry Night',
-  artist: 'Vincent van Gogh',
-  dateCreated: 'June 1889',
-  medium: 'Oil on canvas',
-  dimensions: '73.7 cm × 92.1 cm (29 in × 36.25 in)',
-  currentLocation: 'Museum of Modern Art, New York City',
-  description: 'The Starry Night is an oil-on-canvas painting by the Dutch Post-Impressionist painter Vincent van Gogh. Painted in June 1889, it depicts the view from the east-facing window of his asylum room at Saint-Rémy-de-Provence, just before sunrise, with the addition of an imaginary village.',
-  imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/600px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg',
-  provenance: [
-    {
-      date: 'June 1889',
-      event: 'Created',
-      owner: 'Vincent van Gogh',
-      location: 'Saint-Rémy-de-Provence, France',
-    },
-    {
-      date: 'July 1890',
-      event: 'Inherited',
-      owner: 'Theo van Gogh',
-      location: 'Paris, France',
-    },
-    {
-      date: '1891',
-      event: 'Inherited',
-      owner: 'Johanna van Gogh-Bonger',
-      location: 'Netherlands',
-    },
-    {
-      date: '1900',
-      event: 'Sold',
-      owner: 'Julien Leclercq',
-      location: 'Paris, France',
-    },
-    {
-      date: '1901',
-      event: 'Sold',
-      owner: 'Émile Schuffenecker',
-      location: 'Paris, France',
-    },
-    {
-      date: '1941',
-      event: 'Acquired',
-      owner: 'Museum of Modern Art',
-      location: 'New York City, USA',
-    },
-  ],
-  externalLinks: {
-    dbpedia: 'http://dbpedia.org/resource/The_Starry_Night',
-    wikidata: 'https://www.wikidata.org/wiki/Q45585',
-    getty: 'http://vocab.getty.edu/aat/300177435',
-  },
+// Helper to extract a numeric year from various date formats
+const extractYear = (dateStr: string): number | null => {
+  // Try ISO format first (YYYY-MM-DD or YYYY)
+  const isoMatch = dateStr.match(/^(\d{4})/);
+  if (isoMatch) return parseInt(isoMatch[1], 10);
+  
+  // Try "c. YYYY" or "circa YYYY" format
+  const circaMatch = dateStr.match(/c\.?\s*(\d{4})/i);
+  if (circaMatch) return parseInt(circaMatch[1], 10);
+  
+  // Try extracting any 4-digit year
+  const yearMatch = dateStr.match(/\b(\d{4})\b/);
+  if (yearMatch) return parseInt(yearMatch[1], 10);
+  
+  return null;
+};
+
+// Helper to format ISO dates to full readable dates (e.g., "May 15, 1838")
+const formatDate = (dateStr: string): string => {
+  if (!dateStr) return '';
+  
+  // Extract date part if it includes time
+  let datePart = dateStr;
+  if (dateStr.includes('T')) {
+    datePart = dateStr.split('T')[0];
+  }
+  
+  // Handle YYYY-MM-DD format
+  const isoMatch = datePart.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    const date = new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
+    return date.toLocaleDateString('en-US', { 
+      year: 'numeric', 
+      month: 'long', 
+      day: 'numeric' 
+    });
+  }
+  
+  // Handle YYYY-MM format
+  const yearMonthMatch = datePart.match(/^(\d{4})-(\d{2})$/);
+  if (yearMonthMatch) {
+    const [, year, month] = yearMonthMatch;
+    const date = new Date(parseInt(year), parseInt(month) - 1, 1);
+    return date.toLocaleDateString('en-US', { 
+      year: 'numeric', 
+      month: 'long'
+    });
+  }
+  
+  // Handle just YYYY
+  if (datePart.match(/^\d{4}$/)) {
+    return datePart;
+  }
+  
+  // Return as-is for other formats
+  return dateStr;
 };
 
 const ArtworkDetailPage = () => {
   const { id } = useParams<{ id: string }>();
+  
+  // State
+  const [artwork, setArtwork] = useState<Artwork | null>(null);
+  const [provenance, setProvenance] = useState<ProvenanceRecord[]>([]);
+  const [enrichment, setEnrichment] = useState<ArtworkEnrichment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
 
-  // In real implementation, fetch artwork by id
-  const artwork = placeholderArtwork;
+  // Fetch artwork data
+  const fetchArtwork = useCallback(async () => {
+    if (!id) return;
+    
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+    
+    try {
+      // Fetch artwork details
+      const artworkResponse = await artworkApi.getById(id);
+      setArtwork(artworkResponse.data);
+      
+      // Fetch provenance in parallel
+      const [provenanceResponse, enrichmentResponse] = await Promise.allSettled([
+        artworkApi.getProvenance(id),
+        artworkApi.getEnrichment(id)
+      ]);
+      
+      if (provenanceResponse.status === 'fulfilled') {
+        // Sort by order if available, fallback to date, push undefined to end
+        const sortedProvenance = [...provenanceResponse.value.data].sort((a, b) => {
+          // Both have order - sort by order
+          if (a.order !== undefined && b.order !== undefined) {
+            return a.order - b.order;
+          }
+          // Only a has order - a comes first
+          if (a.order !== undefined) {
+            return -1;
+          }
+          // Only b has order - b comes first
+          if (b.order !== undefined) {
+            return 1;
+          }
+          // Neither has order - try sorting by date using year extraction
+          if (a.date && b.date) {
+            const yearA = extractYear(a.date);
+            const yearB = extractYear(b.date);
+            if (yearA !== null && yearB !== null) {
+              return yearA - yearB;
+            }
+            // If only one has a parseable year, prioritize it
+            if (yearA !== null) return -1;
+            if (yearB !== null) return 1;
+            // Fallback to lexicographic comparison for unparseable dates
+            return a.date.localeCompare(b.date);
+          }
+          // Push records without date to end
+          if (a.date) return -1;
+          if (b.date) return 1;
+          return 0;
+        });
+        setProvenance(sortedProvenance);
+      } else {
+        console.warn('Failed to fetch provenance:', provenanceResponse.reason);
+      }
+      
+      if (enrichmentResponse.status === 'fulfilled') {
+        setEnrichment(enrichmentResponse.value.data);
+      } else {
+        console.warn('Failed to fetch enrichment:', enrichmentResponse.reason);
+      }
+    } catch (err: unknown) {
+      console.error('Failed to fetch artwork:', err);
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosError = err as { response?: { status?: number } };
+        if (axiosError.response?.status === 404) {
+          setNotFound(true);
+        } else {
+          setError('Failed to load artwork details. Please try again.');
+        }
+      } else {
+        setError('Failed to load artwork details. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchArtwork();
+  }, [fetchArtwork]);
+
+  // Generate external links from enrichment or artwork data
+  // Merge both sources: prefer enrichment data, fallback to artwork.externalLinks per link type
+  const getExternalLinks = () => {
+    const links: { name: string; url: string }[] = [];
+    
+    // DBpedia: try enrichment first, fallback to artwork.externalLinks
+    if (enrichment?.dbpedia?.uri) {
+      links.push({ name: 'DBpedia', url: enrichment.dbpedia.uri });
+    } else if (artwork?.externalLinks?.dbpedia) {
+      links.push({ name: 'DBpedia', url: artwork.externalLinks.dbpedia });
+    }
+    
+    // Wikidata: try enrichment first, fallback to artwork.externalLinks
+    if (enrichment?.wikidata?.uri) {
+      // Convert entity URI to wiki page URL
+      const wikidataId = enrichment.wikidata.uri.split('/').pop();
+      // Only add if we got a valid Wikidata ID (e.g., Q12345)
+      if (wikidataId && /^Q\d+$/.test(wikidataId)) {
+        links.push({ name: 'Wikidata', url: `https://www.wikidata.org/wiki/${wikidataId}` });
+      } else if (enrichment.wikidata.uri.startsWith('http')) {
+        // Fallback: use the original URI if it's already a valid URL
+        links.push({ name: 'Wikidata', url: enrichment.wikidata.uri });
+      }
+    } else if (artwork?.externalLinks?.wikidata) {
+      links.push({ name: 'Wikidata', url: artwork.externalLinks.wikidata });
+    }
+    
+    // Getty: try enrichment first, fallback to artwork.externalLinks
+    if (enrichment?.getty && enrichment.getty.length > 0) {
+      links.push({ name: 'Getty AAT', url: enrichment.getty[0].uri });
+    } else if (artwork?.externalLinks?.getty) {
+      links.push({ name: 'Getty AAT', url: artwork.externalLinks.getty });
+    }
+    
+    return links;
+  };
+
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-parchment">
+        {/* Breadcrumb skeleton */}
+        <div className="border-b border-bronze/20 bg-ivory">
+          <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+            <div className="h-4 w-48 animate-pulse rounded bg-parchment-dark" />
+          </div>
+        </div>
+        <ArtworkDetailSkeleton />
+      </div>
+    );
+  }
+
+  // Not found state
+  if (notFound) {
+    return (
+      <div className="min-h-screen bg-parchment">
+        <NotFound 
+          itemType="artwork" 
+          backLink="/artworks" 
+          backLinkText="Back to collection" 
+        />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error || !artwork) {
+    return (
+      <div className="min-h-screen bg-parchment">
+        <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+          <ErrorMessage
+            message={error || 'Unable to load artwork'}
+            onRetry={fetchArtwork}
+            showHomeLink
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const externalLinks = getExternalLinks();
 
   return (
     <div 
@@ -80,7 +257,7 @@ const ArtworkDetailPage = () => {
               Collection
             </Link>
             <span className="text-bronze">/</span>
-            <span className="text-charcoal" property="name">{artwork.title}</span>
+            <span className="text-charcoal truncate max-w-xs" property="name">{artwork.title}</span>
           </nav>
         </div>
       </div>
@@ -89,12 +266,15 @@ const ArtworkDetailPage = () => {
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
         <div className="grid gap-12 lg:grid-cols-2">
           {/* Image */}
-          <div className="overflow-hidden rounded-2xl border border-bronze/20 bg-ivory shadow-lg">
-            <img
+          <div className="overflow-hidden rounded-2xl border border-bronze/20 bg-ivory shadow-lg self-start">
+            <OptimizedImage
               src={artwork.imageUrl}
               alt={artwork.title}
               property="image"
-              className="w-full object-cover"
+              width={800}
+              className="w-full h-auto block"
+              placeholderClassName="w-full aspect-[4/3]"
+              shrinkOnLoad={true}
             />
           </div>
 
@@ -104,44 +284,100 @@ const ArtworkDetailPage = () => {
               {artwork.title}
             </h1>
             
-            <p className="mt-2 text-xl text-charcoal-light">
-              by <span property="creator" typeof="Person"><span property="name">{artwork.artist}</span></span>
-            </p>
+            {artwork.artist && (
+              <p className="mt-2 text-xl text-charcoal-light">
+                by <span property="creator" typeof="Person"><span property="name">{artwork.artist}</span></span>
+              </p>
+            )}
 
             <div className="mt-8 space-y-4">
-              <div className="flex border-b border-bronze/10 pb-4">
-                <span className="w-32 font-medium text-charcoal-light">Date:</span>
-                <span className="text-charcoal" property="dateCreated">{artwork.dateCreated}</span>
-              </div>
-              <div className="flex border-b border-bronze/10 pb-4">
-                <span className="w-32 font-medium text-charcoal-light">Medium:</span>
-                <span className="text-charcoal" property="artMedium">{artwork.medium}</span>
-              </div>
-              <div className="flex border-b border-bronze/10 pb-4">
-                <span className="w-32 font-medium text-charcoal-light">Dimensions:</span>
-                <span className="text-charcoal">{artwork.dimensions}</span>
-              </div>
-              <div className="flex border-b border-bronze/10 pb-4">
-                <span className="w-32 font-medium text-charcoal-light">Location:</span>
-                <span className="text-charcoal" property="contentLocation">{artwork.currentLocation}</span>
-              </div>
+              {artwork.dateCreated && (
+                <div className="flex border-b border-bronze/10 pb-4">
+                  <span className="w-32 font-medium text-charcoal-light">Date:</span>
+                  <span className="text-charcoal" property="dateCreated">{artwork.dateCreated}</span>
+                </div>
+              )}
+              {artwork.medium && (
+                <div className="flex border-b border-bronze/10 pb-4">
+                  <span className="w-32 font-medium text-charcoal-light">Medium:</span>
+                  <span className="text-charcoal" property="artMedium">{artwork.medium}</span>
+                </div>
+              )}
+              {artwork.dimensions && (
+                <div className="flex border-b border-bronze/10 pb-4">
+                  <span className="w-32 font-medium text-charcoal-light">Dimensions:</span>
+                  <span className="text-charcoal">{artwork.dimensions}</span>
+                </div>
+              )}
+              {artwork.period && (
+                <div className="flex border-b border-bronze/10 pb-4">
+                  <span className="w-32 font-medium text-charcoal-light">Period:</span>
+                  <span className="text-charcoal">{artwork.period}</span>
+                </div>
+              )}
+              {artwork.style && (
+                <div className="flex border-b border-bronze/10 pb-4">
+                  <span className="w-32 font-medium text-charcoal-light">Style:</span>
+                  <span className="text-charcoal">{artwork.style}</span>
+                </div>
+              )}
+              {artwork.currentLocation && (
+                <div className="flex border-b border-bronze/10 pb-4">
+                  <span className="w-32 font-medium text-charcoal-light">Location:</span>
+                  <span className="text-charcoal" property="contentLocation">{artwork.currentLocation}</span>
+                </div>
+              )}
             </div>
 
-            <div className="mt-8">
-              <h2 className="font-heading text-lg font-semibold text-charcoal">Description</h2>
-              <p className="mt-3 leading-relaxed text-charcoal-light" property="description">
-                {artwork.description}
-              </p>
-            </div>
+            {artwork.description && (
+              <div className="mt-8">
+                <h2 className="font-heading text-lg font-semibold text-charcoal">Description</h2>
+                <p className="mt-3 leading-relaxed text-charcoal-light" property="description">
+                  {artwork.description}
+                </p>
+              </div>
+            )}
+
+            {/* Artist Info from Enrichment (external or local) */}
+            {(enrichment?.artist_dbpedia || enrichment?.artist_wikidata || enrichment?.artist_local) && (
+              <div className="mt-8 rounded-xl border border-bronze/20 bg-ivory p-6">
+                <h2 className="font-heading text-lg font-semibold text-charcoal">About the Artist</h2>
+                {/* Artist description - prefer external, fallback to local */}
+                {(enrichment.artist_dbpedia?.abstract || enrichment.artist_wikidata?.description || enrichment.artist_local?.description) && (
+                  <p className="mt-3 text-sm leading-relaxed text-charcoal-light">
+                    {enrichment.artist_dbpedia?.abstract || enrichment.artist_wikidata?.description || enrichment.artist_local?.description}
+                  </p>
+                )}
+                {/* Birth and death dates - prefer external, fallback to local */}
+                {(() => {
+                  const birthDate = enrichment.artist_dbpedia?.birthDate || enrichment.artist_wikidata?.birthDate || enrichment.artist_local?.birthDate;
+                  const deathDate = enrichment.artist_dbpedia?.deathDate || enrichment.artist_wikidata?.deathDate || enrichment.artist_local?.deathDate;
+                  const nationality = enrichment.artist_local?.nationality;
+                  
+                  if (birthDate || deathDate || nationality) {
+                    return (
+                      <p className="mt-2 text-sm text-bronze">
+                        {nationality && <span>{nationality} • </span>}
+                        {birthDate && <span>Born: {formatDate(birthDate)}</span>}
+                        {birthDate && deathDate && ' • '}
+                        {deathDate && <span>Died: {formatDate(deathDate)}</span>}
+                      </p>
+                    );
+                  }
+                  return null;
+                })()}
+              </div>
+            )}
 
             {/* External Links */}
-            {artwork.externalLinks && (
+            {externalLinks.length > 0 && (
               <div className="mt-8">
                 <h2 className="font-heading text-lg font-semibold text-charcoal">Linked Data</h2>
                 <div className="mt-3 flex flex-wrap gap-3">
-                  {artwork.externalLinks.dbpedia && (
+                  {externalLinks.map((link) => (
                     <a
-                      href={artwork.externalLinks.dbpedia}
+                      key={link.name}
+                      href={link.url}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-2 rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal hover:border-gold hover:text-gold transition-colors"
@@ -149,42 +385,22 @@ const ArtworkDetailPage = () => {
                       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                       </svg>
-                      DBpedia
+                      {link.name}
                     </a>
-                  )}
-                  {artwork.externalLinks.wikidata && (
-                    <a
-                      href={artwork.externalLinks.wikidata}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal hover:border-gold hover:text-gold transition-colors"
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                      </svg>
-                      Wikidata
-                    </a>
-                  )}
-                  {artwork.externalLinks.getty && (
-                    <a
-                      href={artwork.externalLinks.getty}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal hover:border-gold hover:text-gold transition-colors"
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                      </svg>
-                      Getty AAT
-                    </a>
-                  )}
+                  ))}
                 </div>
               </div>
             )}
 
             {/* QR Code Button */}
             <div className="mt-8">
-              <button className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-gold to-gold-dark px-6 py-3 font-medium text-charcoal shadow-md hover:shadow-lg transition-shadow">
+              <button 
+                onClick={() => {
+                  // Future: Implement QR code modal
+                  alert('QR Code feature coming soon!');
+                }}
+                className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-gold to-gold-dark px-6 py-3 font-medium text-charcoal shadow-md hover:shadow-lg transition-shadow"
+              >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
                 </svg>
@@ -195,50 +411,57 @@ const ArtworkDetailPage = () => {
         </div>
 
         {/* Provenance Timeline */}
-        <div className="mt-16">
-          <h2 className="font-heading text-2xl font-bold text-charcoal">Provenance History</h2>
-          <p className="mt-2 text-charcoal-light">
-            Trace the ownership and location history of this artwork.
-          </p>
+        {provenance.length > 0 && (
+          <div className="mt-16">
+            <h2 className="font-heading text-2xl font-bold text-charcoal">Provenance History</h2>
+            <p className="mt-2 text-charcoal-light">
+              Trace the ownership and location history of this artwork.
+            </p>
 
-          <div className="mt-8">
-            <div className="relative border-l-2 border-gold/30 pl-8">
-              {artwork.provenance.map((record, index) => (
-                <div 
-                  key={index}
-                  className="relative mb-8 last:mb-0"
-                >
-                  {/* Timeline dot */}
-                  <div className="absolute -left-[41px] flex h-6 w-6 items-center justify-center rounded-full border-2 border-gold bg-ivory">
-                    <div className="h-2 w-2 rounded-full bg-gold" />
-                  </div>
+            <div className="mt-8">
+              <div className="relative border-l-2 border-gold/30 pl-8">
+                {provenance.map((record, index) => (
+                  <div 
+                    key={record.id || index}
+                    className="relative mb-8 last:mb-0"
+                  >
+                    {/* Timeline dot */}
+                    <div className="absolute -left-[41px] flex h-6 w-6 items-center justify-center rounded-full border-2 border-gold bg-ivory">
+                      <div className="h-2 w-2 rounded-full bg-gold" />
+                    </div>
 
-                  <div className="rounded-xl border border-bronze/20 bg-ivory p-6 shadow-sm">
-                    <div className="flex flex-wrap items-center gap-4">
-                      <span className="rounded-full bg-gold/10 px-3 py-1 text-sm font-medium text-gold">
-                        {record.date}
-                      </span>
-                      <span className="text-sm font-medium uppercase tracking-wider text-burgundy">
-                        {record.event}
-                      </span>
-                    </div>
-                    <div className="mt-3 space-y-1">
-                      <p className="font-medium text-charcoal">{record.owner}</p>
-                      <p className="text-sm text-charcoal-light">{record.location}</p>
+                    <div className="rounded-xl border border-bronze/20 bg-ivory p-6 shadow-sm">
+                      <div className="flex flex-wrap items-center gap-4">
+                        {record.date && (
+                          <span className="rounded-full bg-gold/10 px-3 py-1 text-sm font-medium text-gold">
+                            {extractYear(record.date) ?? record.date}
+                          </span>
+                        )}
+                        <span className="text-sm font-medium uppercase tracking-wider text-burgundy">
+                          {record.event}
+                        </span>
+                      </div>
+                      <div className="mt-3 space-y-1">
+                        {record.owner && (
+                          <p className="font-medium text-charcoal">{record.owner}</p>
+                        )}
+                        {record.location && (
+                          <p className="text-sm text-charcoal-light">{record.location}</p>
+                        )}
+                        {record.description && (
+                          <p className="mt-2 text-sm text-charcoal-light">{record.description}</p>
+                        )}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
-
-      {/* Debug: show artwork ID */}
-      <div className="hidden">Artwork ID: {id}</div>
     </div>
   );
 };
 
 export default ArtworkDetailPage;
-

--- a/frontend/src/pages/ArtworksPage.tsx
+++ b/frontend/src/pages/ArtworksPage.tsx
@@ -1,58 +1,86 @@
-import { Link } from 'react-router-dom';
-
-// Placeholder artwork data (to be replaced with API calls)
-const placeholderArtworks = [
-  {
-    id: '1',
-    title: 'The Starry Night',
-    artist: 'Vincent van Gogh',
-    dateCreated: '1889',
-    medium: 'Oil on canvas',
-    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/300px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg',
-  },
-  {
-    id: '2',
-    title: 'Mona Lisa',
-    artist: 'Leonardo da Vinci',
-    dateCreated: 'c. 1503–1519',
-    medium: 'Oil on poplar panel',
-    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg/300px-Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg',
-  },
-  {
-    id: '3',
-    title: 'The Persistence of Memory',
-    artist: 'Salvador Dalí',
-    dateCreated: '1931',
-    medium: 'Oil on canvas',
-    imageUrl: 'https://upload.wikimedia.org/wikipedia/en/d/dd/The_Persistence_of_Memory.jpg',
-  },
-  {
-    id: '4',
-    title: 'Girl with a Pearl Earring',
-    artist: 'Johannes Vermeer',
-    dateCreated: 'c. 1665',
-    medium: 'Oil on canvas',
-    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/1665_Girl_with_a_Pearl_Earring.jpg/300px-1665_Girl_with_a_Pearl_Earring.jpg',
-  },
-  {
-    id: '5',
-    title: 'The Birth of Venus',
-    artist: 'Sandro Botticelli',
-    dateCreated: 'c. 1484–1486',
-    medium: 'Tempera on canvas',
-    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg/400px-Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg',
-  },
-  {
-    id: '6',
-    title: 'The Night Watch',
-    artist: 'Rembrandt van Rijn',
-    dateCreated: '1642',
-    medium: 'Oil on canvas',
-    imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/The_Night_Watch_-_HD.jpg/400px-The_Night_Watch_-_HD.jpg',
-  },
-];
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { artworkApi, type Artwork, type ArtworkListResponse } from '../services/api';
+import { ArtworkCard, ArtworkGridSkeleton, ErrorMessage } from '../components';
 
 const ArtworksPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  
+  // State
+  const [artworks, setArtworks] = useState<Artwork[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [total, setTotal] = useState(0);
+  
+  // Get filter values from URL params
+  const parsedPage = parseInt(searchParams.get('page') || '1', 10);
+  const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
+  const search = searchParams.get('search') || '';
+  const period = searchParams.get('period') || '';
+  const limit = 12;
+
+  // Fetch artworks
+  const fetchArtworks = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const params: Record<string, unknown> = { page, limit };
+      if (search) params.search = search;
+      if (period) params.period = period;
+      
+      const response = await artworkApi.getAll(params as { page?: number; limit?: number; search?: string; artist?: string; period?: string });
+      const data: ArtworkListResponse = response.data;
+      
+      // Backend now properly deduplicates by preferring English titles
+      setArtworks(data.items);
+      setTotal(data.total);
+    } catch (err) {
+      console.error('Failed to fetch artworks:', err);
+      setError('Failed to load artworks. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search, period, limit]);
+
+  useEffect(() => {
+    fetchArtworks();
+  }, [fetchArtworks]);
+
+  // Handle search input
+  const handleSearchChange = (value: string) => {
+    const newParams = new URLSearchParams(searchParams);
+    if (value) {
+      newParams.set('search', value);
+    } else {
+      newParams.delete('search');
+    }
+    newParams.set('page', '1'); // Reset to first page
+    setSearchParams(newParams);
+  };
+
+  // Handle period filter
+  const handlePeriodChange = (value: string) => {
+    const newParams = new URLSearchParams(searchParams);
+    if (value) {
+      newParams.set('period', value);
+    } else {
+      newParams.delete('period');
+    }
+    newParams.set('page', '1'); // Reset to first page
+    setSearchParams(newParams);
+  };
+
+  // Handle pagination
+  const goToPage = (newPage: number) => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set('page', String(newPage));
+    setSearchParams(newParams);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const totalPages = Math.ceil(total / limit);
+
   return (
     <div className="min-h-screen bg-parchment">
       {/* Page Header */}
@@ -79,6 +107,8 @@ const ArtworksPage = () => {
                 type="text"
                 id="search"
                 placeholder="Title or artist..."
+                value={search}
+                onChange={(e) => handleSearchChange(e.target.value)}
                 className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal placeholder:text-bronze focus:border-gold focus:outline-none focus:ring-1 focus:ring-gold"
               />
             </div>
@@ -88,93 +118,172 @@ const ArtworksPage = () => {
               </label>
               <select
                 id="period"
+                value={period}
+                onChange={(e) => handlePeriodChange(e.target.value)}
                 className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal focus:border-gold focus:outline-none focus:ring-1 focus:ring-gold"
               >
                 <option value="">All Periods</option>
-                <option value="renaissance">Renaissance</option>
-                <option value="baroque">Baroque</option>
-                <option value="impressionism">Impressionism</option>
-                <option value="modern">Modern</option>
+                <option value="Renaissance">Renaissance</option>
+                <option value="Baroque">Baroque</option>
+                <option value="Impressionism">Impressionism</option>
+                <option value="Post-Impressionism">Post-Impressionism</option>
+                <option value="Expressionism">Expressionism</option>
+                <option value="Cubism">Cubism</option>
+                <option value="Surrealism">Surrealism</option>
+                <option value="Art Nouveau">Art Nouveau</option>
+                <option value="Dutch Golden Age">Dutch Golden Age</option>
+                <option value="Romanian">Romanian</option>
               </select>
             </div>
-            <div className="flex items-center gap-2">
-              <label htmlFor="medium" className="text-sm font-medium text-charcoal-light">
-                Medium:
-              </label>
-              <select
-                id="medium"
-                className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal focus:border-gold focus:outline-none focus:ring-1 focus:ring-gold"
+            {(search || period) && (
+              <button
+                onClick={() => {
+                  setSearchParams(new URLSearchParams());
+                }}
+                className="text-sm text-burgundy hover:text-burgundy-dark transition-colors"
               >
-                <option value="">All Media</option>
-                <option value="oil">Oil</option>
-                <option value="watercolor">Watercolor</option>
-                <option value="tempera">Tempera</option>
-                <option value="sculpture">Sculpture</option>
-              </select>
-            </div>
+                Clear filters
+              </button>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Artworks Grid */}
+      {/* Content */}
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {placeholderArtworks.map((artwork) => (
-            <Link
-              key={artwork.id}
-              to={`/artworks/${artwork.id}`}
-              className="group overflow-hidden rounded-2xl border border-bronze/20 bg-ivory shadow-sm transition-all hover:border-gold/40 hover:shadow-lg"
-            >
-              {/* Image */}
-              <div className="aspect-[4/3] overflow-hidden bg-parchment-dark">
-                <img
-                  src={artwork.imageUrl}
-                  alt={artwork.title}
-                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                />
-              </div>
-              
-              {/* Content */}
-              <div className="p-6">
-                <h2 className="font-heading text-xl font-semibold text-charcoal group-hover:text-gold transition-colors">
-                  {artwork.title}
-                </h2>
-                <p className="mt-2 text-charcoal-light">
-                  {artwork.artist}
-                </p>
-                <div className="mt-4 flex items-center justify-between text-sm text-bronze">
-                  <span>{artwork.dateCreated}</span>
-                  <span>{artwork.medium}</span>
-                </div>
-                <div className="mt-4 flex items-center gap-2 text-sm text-gold opacity-0 transition-opacity group-hover:opacity-100">
-                  <span>View Provenance</span>
-                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-                  </svg>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
+        {/* Error State */}
+        {error && (
+          <ErrorMessage
+            message={error}
+            onRetry={fetchArtworks}
+            className="mb-8"
+          />
+        )}
 
-        {/* Pagination */}
-        <div className="mt-12 flex justify-center">
-          <nav className="flex items-center gap-2">
-            <button className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-colors">
-              Previous
-            </button>
-            <span className="px-4 py-2 text-sm text-charcoal">
-              Page 1 of 1
-            </span>
-            <button className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-colors">
-              Next
-            </button>
-          </nav>
-        </div>
+        {/* Loading State */}
+        {loading && <ArtworkGridSkeleton count={limit} />}
+
+        {/* Empty State */}
+        {!loading && !error && artworks.length === 0 && (
+          <div className="py-16 text-center">
+            <svg
+              className="mx-auto h-16 w-16 text-bronze"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            <h3 className="mt-4 font-heading text-xl font-semibold text-charcoal">
+              No artworks found
+            </h3>
+            <p className="mt-2 text-charcoal-light">
+              {search || period
+                ? 'Try adjusting your search or filters.'
+                : 'Check back later for new additions to the collection.'}
+            </p>
+          </div>
+        )}
+
+        {/* Artworks Grid */}
+        {!loading && !error && artworks.length > 0 && (
+          <>
+            {/* Results count */}
+            <p className="mb-6 text-sm text-charcoal-light">
+              Showing {(page - 1) * limit + 1}-{(page - 1) * limit + artworks.length} of {total} artworks
+            </p>
+
+            <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              {artworks.map((artwork) => (
+                <ArtworkCard key={artwork.id} artwork={artwork} />
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="mt-12 flex justify-center">
+                <nav className="flex items-center gap-2">
+                  <button
+                    onClick={() => goToPage(page - 1)}
+                    disabled={page <= 1}
+                    className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Previous
+                  </button>
+                  
+                  <div className="flex items-center gap-1">
+                    {/* First page */}
+                    {page > 2 && (
+                      <>
+                        <button
+                          onClick={() => goToPage(1)}
+                          className="rounded-lg px-3 py-2 text-sm text-charcoal-light hover:text-charcoal transition-colors"
+                        >
+                          1
+                        </button>
+                        {page > 3 && <span className="px-2 text-bronze">...</span>}
+                      </>
+                    )}
+                    
+                    {/* Previous page */}
+                    {page > 1 && (
+                      <button
+                        onClick={() => goToPage(page - 1)}
+                        className="rounded-lg px-3 py-2 text-sm text-charcoal-light hover:text-charcoal transition-colors"
+                      >
+                        {page - 1}
+                      </button>
+                    )}
+                    
+                    {/* Current page */}
+                    <span className="rounded-lg bg-gold/20 px-3 py-2 text-sm font-medium text-gold">
+                      {page}
+                    </span>
+                    
+                    {/* Next page */}
+                    {page < totalPages && (
+                      <button
+                        onClick={() => goToPage(page + 1)}
+                        className="rounded-lg px-3 py-2 text-sm text-charcoal-light hover:text-charcoal transition-colors"
+                      >
+                        {page + 1}
+                      </button>
+                    )}
+                    
+                    {/* Last page */}
+                    {page < totalPages - 1 && (
+                      <>
+                        {page < totalPages - 2 && <span className="px-2 text-bronze">...</span>}
+                        <button
+                          onClick={() => goToPage(totalPages)}
+                          className="rounded-lg px-3 py-2 text-sm text-charcoal-light hover:text-charcoal transition-colors"
+                        >
+                          {totalPages}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                  
+                  <button
+                    onClick={() => goToPage(page + 1)}
+                    disabled={page >= totalPages}
+                    className="rounded-lg border border-bronze/30 bg-ivory px-4 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Next
+                  </button>
+                </nav>
+              </div>
+            )}
+          </>
+        )}
       </div>
     </div>
   );
 };
 
 export default ArtworksPage;
-

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,28 @@
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { artworkApi, type Artwork } from '../services/api';
+import { ArtworkCard, ArtworkCardSkeleton } from '../components';
 
 const HomePage = () => {
+  const [featuredArtworks, setFeaturedArtworks] = useState<Artwork[]>([]);
+  const [loadingFeatured, setLoadingFeatured] = useState(true);
+
+  useEffect(() => {
+    const fetchFeaturedArtworks = async () => {
+      try {
+        const response = await artworkApi.getAll({ limit: 6 });
+        // Backend now properly deduplicates by preferring English titles
+        setFeaturedArtworks(response.data.items);
+      } catch (err) {
+        console.error('Failed to fetch featured artworks:', err);
+      } finally {
+        setLoadingFeatured(false);
+      }
+    };
+
+    fetchFeaturedArtworks();
+  }, []);
+
   return (
     <div className="relative">
       {/* Hero Section */}
@@ -51,8 +73,68 @@ const HomePage = () => {
         <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-parchment to-transparent" />
       </section>
 
+      {/* Featured Artworks Section */}
+      <section className="bg-parchment py-16">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="font-heading text-3xl font-bold text-charcoal">
+                Featured Artworks
+              </h2>
+              <p className="mt-2 text-charcoal-light">
+                Discover masterpieces with rich provenance histories
+              </p>
+            </div>
+            <Link
+              to="/artworks"
+              className="hidden sm:inline-flex items-center gap-2 text-gold hover:text-gold-dark transition-colors"
+            >
+              View all
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+              </svg>
+            </Link>
+          </div>
+
+          {/* Featured Grid */}
+          <div className="mt-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {loadingFeatured ? (
+              <>
+                <ArtworkCardSkeleton />
+                <ArtworkCardSkeleton />
+                <ArtworkCardSkeleton />
+                <ArtworkCardSkeleton />
+                <ArtworkCardSkeleton />
+                <ArtworkCardSkeleton />
+              </>
+            ) : featuredArtworks.length > 0 ? (
+              featuredArtworks.slice(0, 6).map((artwork) => (
+                <ArtworkCard key={artwork.id} artwork={artwork} />
+              ))
+            ) : (
+              <div className="col-span-full py-12 text-center">
+                <p className="text-charcoal-light">No artworks available yet.</p>
+              </div>
+            )}
+          </div>
+
+          {/* Mobile view all link */}
+          <div className="mt-8 text-center sm:hidden">
+            <Link
+              to="/artworks"
+              className="inline-flex items-center gap-2 text-gold hover:text-gold-dark transition-colors"
+            >
+              View all artworks
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Features Section */}
-      <section className="bg-parchment py-20">
+      <section className="bg-ivory py-20">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <h2 className="font-heading text-3xl font-bold text-charcoal sm:text-4xl">
@@ -65,7 +147,7 @@ const HomePage = () => {
 
           <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
             {/* Feature 1 */}
-            <div className="group rounded-2xl border border-bronze/20 bg-ivory p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
+            <div className="group rounded-2xl border border-bronze/20 bg-parchment p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-burgundy to-burgundy-dark text-ivory">
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
@@ -80,7 +162,7 @@ const HomePage = () => {
             </div>
 
             {/* Feature 2 */}
-            <div className="group rounded-2xl border border-bronze/20 bg-ivory p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
+            <div className="group rounded-2xl border border-bronze/20 bg-parchment p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-gold to-gold-dark text-charcoal">
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
@@ -95,7 +177,7 @@ const HomePage = () => {
             </div>
 
             {/* Feature 3 */}
-            <div className="group rounded-2xl border border-bronze/20 bg-ivory p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
+            <div className="group rounded-2xl border border-bronze/20 bg-parchment p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-bronze to-bronze-light text-ivory">
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -110,7 +192,7 @@ const HomePage = () => {
             </div>
 
             {/* Feature 4 */}
-            <div className="group rounded-2xl border border-bronze/20 bg-ivory p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
+            <div className="group rounded-2xl border border-bronze/20 bg-parchment p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-charcoal to-charcoal-light text-gold">
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
@@ -125,7 +207,7 @@ const HomePage = () => {
             </div>
 
             {/* Feature 5 */}
-            <div className="group rounded-2xl border border-bronze/20 bg-ivory p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
+            <div className="group rounded-2xl border border-bronze/20 bg-parchment p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-burgundy to-burgundy-dark text-ivory">
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -140,7 +222,7 @@ const HomePage = () => {
             </div>
 
             {/* Feature 6 */}
-            <div className="group rounded-2xl border border-bronze/20 bg-ivory p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
+            <div className="group rounded-2xl border border-bronze/20 bg-parchment p-8 shadow-sm transition-all hover:border-gold/40 hover:shadow-md">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-gold to-gold-dark text-charcoal">
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -158,7 +240,7 @@ const HomePage = () => {
       </section>
 
       {/* Data Sources Section */}
-      <section className="border-t border-bronze/20 bg-ivory py-16">
+      <section className="border-t border-bronze/20 bg-parchment py-16">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <h3 className="text-center font-heading text-lg font-medium text-charcoal-light">
             Integrated Knowledge Sources
@@ -187,4 +269,3 @@ const HomePage = () => {
 };
 
 export default HomePage;
-

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -66,8 +66,14 @@ export const api = {
 
 // Artwork-specific API endpoints
 export const artworkApi = {
-  // Get all artworks with optional pagination
-  getAll: (params?: { page?: number; limit?: number; search?: string }) => 
+  // Get all artworks with optional pagination and filtering
+  getAll: (params?: { 
+    page?: number; 
+    limit?: number; 
+    search?: string;
+    artist?: string;
+    period?: string;
+  }) => 
     api.get<ArtworkListResponse>('/artworks', { params }),
   
   // Get single artwork by ID
@@ -77,6 +83,10 @@ export const artworkApi = {
   // Get artwork provenance history
   getProvenance: (id: string) => 
     api.get<ProvenanceRecord[]>(`/artworks/${id}/provenance`),
+  
+  // Get enrichment data from external sources
+  getEnrichment: (id: string) => 
+    api.get<ArtworkEnrichment>(`/artworks/${id}/enrich`),
   
   // Create new artwork
   create: (data: CreateArtworkRequest) => 
@@ -105,7 +115,7 @@ export const searchApi = {
     api.get<Artwork[]>(`/artworks/${artworkId}/recommendations`),
 };
 
-// Type definitions (to be expanded based on backend schema)
+// Type definitions matching backend schema
 export interface Artwork {
   id: string;
   title: string;
@@ -117,22 +127,94 @@ export interface Artwork {
   description?: string;
   imageUrl?: string;
   currentLocation?: string;
+  period?: string;
+  style?: string;
   provenance?: ProvenanceRecord[];
   externalLinks?: {
     dbpedia?: string;
     wikidata?: string;
     getty?: string;
   };
+  // JSON-LD fields
+  '@context'?: Record<string, unknown>;
+  '@type'?: string;
 }
 
 export interface ProvenanceRecord {
   id: string;
-  date: string;
+  date?: string;
   event: string;
   owner?: string;
   location?: string;
   description?: string;
   sourceUri?: string;
+  order?: number;
+}
+
+// External enrichment data
+export interface ArtworkEnrichment {
+  artwork_id: string;
+  dbpedia?: DBpediaArtworkInfo;
+  wikidata?: WikidataArtworkInfo;
+  getty?: GettyTerm[];
+  artist_dbpedia?: DBpediaArtistInfo;
+  artist_wikidata?: WikidataArtistInfo;
+  artist_local?: LocalArtistInfo;
+}
+
+export interface DBpediaArtworkInfo {
+  uri: string;
+  label?: string;
+  abstract?: string;
+  thumbnail?: string;
+  museum?: string;
+  movement?: string;
+}
+
+export interface WikidataArtworkInfo {
+  uri: string;
+  label?: string;
+  description?: string;
+  image?: string;
+  inception?: string;
+  genre?: string;
+}
+
+export interface GettyTerm {
+  uri: string;
+  prefLabel?: string;
+  scopeNote?: string;
+  broader?: string;
+}
+
+export interface DBpediaArtistInfo {
+  uri: string;
+  name?: string;
+  abstract?: string;
+  birthDate?: string;
+  deathDate?: string;
+  birthPlace?: string;
+  thumbnail?: string;
+}
+
+export interface WikidataArtistInfo {
+  uri: string;
+  name?: string;
+  description?: string;
+  birthDate?: string;
+  deathDate?: string;
+  nationality?: string;
+  image?: string;
+}
+
+export interface LocalArtistInfo {
+  source: string;
+  uri?: string;
+  name?: string;
+  birthDate?: string;
+  deathDate?: string;
+  nationality?: string;
+  description?: string;
 }
 
 export interface ArtworkListResponse {

--- a/fuseki/data/sample-data.ttl
+++ b/fuseki/data/sample-data.ttl
@@ -1,15 +1,15 @@
-@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix owl:     <http://www.w3.org/2002/07/owl#> .
-@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-@prefix dc:      <http://purl.org/dc/elements/1.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix prov:    <http://www.w3.org/ns/prov#> .
-@prefix schema:  <http://schema.org/> .
-@prefix aat:     <http://vocab.getty.edu/aat/> .
-@prefix dbr:     <http://dbpedia.org/resource/> .
-@prefix wd:      <http://www.wikidata.org/entity/> .
-@prefix arp:     <http://example.org/arp#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix schema: <http://schema.org/> .
+@prefix aat: <http://vocab.getty.edu/aat/> .
+@prefix dbr: <http://dbpedia.org/resource/> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix arp: <http://example.org/arp#> .
 
 # =============================================================================
 # SAMPLE DATA - ArP Artwork Provenance
@@ -80,12 +80,87 @@ arp:location_florence a arp:Location ;
 arp:location_amboise a arp:Location ;
     schema:name "Château d'Amboise"@en ;
     schema:address "Amboise, France" ;
-    owl:sameAs dbr:Château_d%27Amboise .
+    owl:sameAs dbr:Château_d%27Amboise, wd:Q237788 .
 
 arp:location_fontainebleau a arp:Location ;
     schema:name "Palace of Fontainebleau"@en ;
     schema:address "Fontainebleau, France" ;
     owl:sameAs dbr:Palace_of_Fontainebleau, wd:Q182811 .
+
+arp:location_saint_remy a arp:Location ;
+    schema:name "Saint-Rémy-de-Provence"@en ;
+    schema:address "Saint-Rémy-de-Provence, Provence-Alpes-Côte d'Azur, France" ;
+    owl:sameAs dbr:Saint-Rémy-de-Provence, wd:Q188571 .
+
+arp:location_mauritshuis a arp:Location, schema:Museum ;
+    schema:name "Mauritshuis"@en ;
+    schema:address "Plein 29, 2511 CS The Hague, Netherlands" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "52.0804"^^xsd:decimal ;
+        schema:longitude "4.3142"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:Mauritshuis, wd:Q221092 .
+
+arp:location_rijksmuseum a arp:Location, schema:Museum ;
+    schema:name "Rijksmuseum"@en ;
+    schema:address "Museumstraat 1, 1071 XX Amsterdam, Netherlands" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "52.3600"^^xsd:decimal ;
+        schema:longitude "4.8852"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:Rijksmuseum, wd:Q190804 .
+
+arp:location_national_gallery_oslo a arp:Location, schema:Museum ;
+    schema:name "National Gallery of Norway"@en ;
+    schema:address "Brynjulf Bulls plass 3, 0250 Oslo, Norway" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "59.9163"^^xsd:decimal ;
+        schema:longitude "10.7385"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:National_Gallery_of_Norway, wd:Q1967082 .
+
+arp:location_reina_sofia a arp:Location, schema:Museum ;
+    schema:name "Museo Reina Sofía"@en ;
+    schema:address "Calle de Santa Isabel, 52, 28012 Madrid, Spain" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "40.4086"^^xsd:decimal ;
+        schema:longitude "-3.6943"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:Museo_Reina_Sofía, wd:Q460889 .
+
+arp:location_belvedere a arp:Location, schema:Museum ;
+    schema:name "Belvedere"@en ;
+    schema:address "Prinz Eugen-Straße 27, 1030 Vienna, Austria" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "48.1914"^^xsd:decimal ;
+        schema:longitude "16.3808"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:Belvedere_Vienna, wd:Q303679 .
+
+arp:location_santa_maria_grazie a arp:Location ;
+    schema:name "Santa Maria delle Grazie"@en ;
+    schema:address "Piazza di Santa Maria delle Grazie, 2, 20123 Milan, Italy" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "45.4660"^^xsd:decimal ;
+        schema:longitude "9.1711"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:Santa_Maria_delle_Grazie, wd:Q210804 .
+
+arp:location_musee_orangerie a arp:Location, schema:Museum ;
+    schema:name "Musée de l'Orangerie"@en ;
+    schema:address "Jardin Tuileries, 75001 Paris, France" ;
+    schema:geo [
+        a schema:GeoCoordinates ;
+        schema:latitude "48.8638"^^xsd:decimal ;
+        schema:longitude "2.3226"^^xsd:decimal
+    ] ;
+    owl:sameAs dbr:Musée_de_l%27Orangerie, wd:Q461032 .
 
 # =============================================================================
 # ARTISTS
@@ -131,7 +206,87 @@ arp:artist_luchian a arp:Artist ;
     schema:deathDate "1916-06-28"^^xsd:date ;
     schema:nationality "Romanian" ;
     dc:description "Romanian painter, considered one of the leading figures in Romanian modern art."@en ;
-    owl:sameAs <http://dbpedia.org/resource/Ștefan_Luchian>, wd:Q558616 .
+    owl:sameAs dbr:Stefan_Luchian, wd:Q558616 .
+
+arp:artist_vermeer a arp:Artist ;
+    schema:name "Johannes Vermeer"@en ;
+    schema:birthDate "1632-10-31"^^xsd:date ;
+    schema:deathDate "1675-12-15"^^xsd:date ;
+    schema:nationality "Dutch" ;
+    dc:description "Dutch Baroque painter who specialized in domestic interior scenes of middle-class life."@en ;
+    owl:sameAs dbr:Johannes_Vermeer, wd:Q41264 .
+
+arp:artist_rembrandt a arp:Artist ;
+    schema:name "Rembrandt van Rijn"@en ;
+    schema:birthDate "1606-07-15"^^xsd:date ;
+    schema:deathDate "1669-10-04"^^xsd:date ;
+    schema:nationality "Dutch" ;
+    dc:description "Dutch Golden Age painter, generally considered one of the greatest visual artists in the history of art."@en ;
+    owl:sameAs dbr:Rembrandt, wd:Q5598 .
+
+arp:artist_munch a arp:Artist ;
+    schema:name "Edvard Munch"@en ;
+    schema:birthDate "1863-12-12"^^xsd:date ;
+    schema:deathDate "1944-01-23"^^xsd:date ;
+    schema:nationality "Norwegian" ;
+    dc:description "Norwegian painter whose best-known work, The Scream, has become one of the most iconic images in art history."@en ;
+    owl:sameAs dbr:Edvard_Munch, wd:Q41406 .
+
+arp:artist_picasso a arp:Artist ;
+    schema:name "Pablo Picasso"@en ;
+    schema:birthDate "1881-10-25"^^xsd:date ;
+    schema:deathDate "1973-04-08"^^xsd:date ;
+    schema:nationality "Spanish" ;
+    dc:description "Spanish painter, sculptor, printmaker, and co-founder of Cubism."@en ;
+    owl:sameAs dbr:Pablo_Picasso, wd:Q5593 .
+
+arp:artist_klimt a arp:Artist ;
+    schema:name "Gustav Klimt"@en ;
+    schema:birthDate "1862-07-14"^^xsd:date ;
+    schema:deathDate "1918-02-06"^^xsd:date ;
+    schema:nationality "Austrian" ;
+    dc:description "Austrian symbolist painter and one of the most prominent members of the Vienna Secession movement."@en ;
+    owl:sameAs dbr:Gustav_Klimt, wd:Q34661 .
+
+arp:artist_dali a arp:Artist ;
+    schema:name "Salvador Dalí"@en ;
+    schema:birthDate "1904-05-11"^^xsd:date ;
+    schema:deathDate "1989-01-23"^^xsd:date ;
+    schema:nationality "Spanish" ;
+    dc:description "Spanish surrealist artist renowned for his technical skill, striking imagery, and bizarre dreamlike paintings."@en ;
+    owl:sameAs dbr:Salvador_Dalí, wd:Q5577 .
+
+arp:artist_monet a arp:Artist ;
+    schema:name "Claude Monet"@en ;
+    schema:birthDate "1840-11-14"^^xsd:date ;
+    schema:deathDate "1926-12-05"^^xsd:date ;
+    schema:nationality "French" ;
+    dc:description "French painter and founder of French Impressionist painting."@en ;
+    owl:sameAs dbr:Claude_Monet, wd:Q296 .
+
+arp:artist_tonitza a arp:Artist ;
+    schema:name "Nicolae Tonitza"@en ;
+    schema:birthDate "1886-04-13"^^xsd:date ;
+    schema:deathDate "1940-02-26"^^xsd:date ;
+    schema:nationality "Romanian" ;
+    dc:description "Romanian painter, graphic artist, and art critic, known for his distinctive portraits of children."@en ;
+    owl:sameAs dbr:Nicolae_Tonitza, wd:Q561835 .
+
+arp:artist_aman a arp:Artist ;
+    schema:name "Theodor Aman"@en ;
+    schema:birthDate "1831-03-20"^^xsd:date ;
+    schema:deathDate "1891-08-19"^^xsd:date ;
+    schema:nationality "Romanian" ;
+    dc:description "Romanian painter, founder of the National School of Fine Arts in Bucharest."@en ;
+    owl:sameAs dbr:Theodor_Aman, wd:Q561153 .
+
+arp:artist_andreescu a arp:Artist ;
+    schema:name "Ion Andreescu"@en ;
+    schema:birthDate "1850-02-15"^^xsd:date ;
+    schema:deathDate "1882-10-22"^^xsd:date ;
+    schema:nationality "Romanian" ;
+    dc:description "Romanian painter considered one of the founders of modern Romanian painting alongside Nicolae Grigorescu."@en ;
+    owl:sameAs dbr:Ion_Andreescu, wd:Q561199 .
 
 # =============================================================================
 # OWNERS
@@ -153,7 +308,7 @@ arp:owner_french_republic a arp:OrganizationOwner ;
 arp:owner_theo_vangogh a arp:PersonOwner ;
     schema:name "Theo van Gogh"@en ;
     dc:description "Dutch art dealer and younger brother of Vincent van Gogh."@en ;
-    owl:sameAs <http://dbpedia.org/resource/Theo_van_Gogh_(art_dealer)>, wd:Q317188 .
+    owl:sameAs dbr:Theo_van_Gogh, wd:Q317188 .
 
 arp:owner_johanna_vangogh a arp:PersonOwner ;
     schema:name "Johanna van Gogh-Bonger"@en ;
@@ -196,6 +351,27 @@ arp:owner_moma a arp:OrganizationOwner ;
     arp:ownerLocation arp:location_moma ;
     owl:sameAs dbr:Museum_of_Modern_Art, wd:Q188740 .
 
+arp:owner_dutch_state a arp:OrganizationOwner ;
+    schema:name "Dutch State"@en ;
+    dc:description "The Kingdom of the Netherlands as custodian of national cultural heritage."@en .
+
+arp:owner_norwegian_state a arp:OrganizationOwner ;
+    schema:name "Norwegian State"@en ;
+    dc:description "The Kingdom of Norway as custodian of national cultural heritage."@en .
+
+arp:owner_spanish_state a arp:OrganizationOwner ;
+    schema:name "Spanish State"@en ;
+    dc:description "The Kingdom of Spain as custodian of national cultural heritage."@en .
+
+arp:owner_austrian_state a arp:OrganizationOwner ;
+    schema:name "Austrian State"@en ;
+    dc:description "The Republic of Austria as custodian of national cultural heritage."@en .
+
+arp:owner_dominican_order a arp:OrganizationOwner ;
+    schema:name "Dominican Order"@en ;
+    dc:description "Catholic religious order that commissioned The Last Supper."@en ;
+    owl:sameAs dbr:Dominican_Order, wd:Q134747 .
+
 # =============================================================================
 # ARTWORK 1: Mona Lisa
 # =============================================================================
@@ -211,8 +387,8 @@ arp:artwork_mona_lisa a arp:Artwork, schema:VisualArtwork, schema:Painting ;
     arp:artworkDimensions "77 cm × 53 cm (30 in × 21 in)" ;
     arp:artworkPeriod "High Renaissance" ;
     arp:artworkStyle "Renaissance" ;
-    schema:image <https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg/800px-Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg> ;
-    schema:artMedium aat:300015050 ;  # Oil paint
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Mona_Lisa,_by_Leonardo_da_Vinci,_from_C2RMF_retouched.jpg> ;
+    schema:artMedium aat:300015050 ;
     arp:currentOwner arp:owner_french_republic ;
     arp:currentLocation arp:location_louvre ;
     owl:sameAs dbr:Mona_Lisa, wd:Q12418 ;
@@ -262,7 +438,7 @@ arp:prov_mona_lisa_004 a arp:ProvenanceEvent ;
 
 arp:artwork_starry_night a arp:Artwork, schema:VisualArtwork, schema:Painting ;
     dc:title "The Starry Night"@en ;
-    dc:title "De sterrennacht"@nl ;
+    dc:title "De sterrennacht"@nl ; 
     dc:creator arp:artist_vangogh ;
     dcterms:created "1889-06"^^xsd:gYearMonth ;
     dc:description "An oil-on-canvas painting depicting a swirling night sky over a village, painted during Van Gogh's stay at the Saint-Paul-de-Mausole asylum."@en ;
@@ -270,8 +446,8 @@ arp:artwork_starry_night a arp:Artwork, schema:VisualArtwork, schema:Painting ;
     arp:artworkDimensions "73.7 cm × 92.1 cm (29 in × 36¼ in)" ;
     arp:artworkPeriod "Post-Impressionism" ;
     arp:artworkStyle "Post-Impressionism" ;
-    schema:image <https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1280px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg> ;
-    schema:artMedium aat:300015050 ;  # Oil paint
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg> ;
+    schema:artMedium aat:300015050 ;
     arp:currentOwner arp:owner_moma ;
     arp:currentLocation arp:location_moma ;
     owl:sameAs dbr:The_Starry_Night, wd:Q45585 ;
@@ -283,6 +459,7 @@ arp:prov_starry_night_001 a arp:ProvenanceEvent ;
     dc:description "Vincent van Gogh painted The Starry Night while staying at the Saint-Paul-de-Mausole asylum in Saint-Rémy-de-Provence."@en ;
     prov:startedAtTime "1889-06-01"^^xsd:date ;
     arp:toOwner arp:artist_vangogh ;
+    arp:eventLocation arp:location_saint_remy ;
     arp:provenanceOrder 1 .
 
 arp:prov_starry_night_002 a arp:ProvenanceEvent ;
@@ -326,8 +503,8 @@ arp:artwork_birth_of_venus a arp:Artwork, schema:VisualArtwork, schema:Painting 
     arp:artworkDimensions "172.5 cm × 278.9 cm (67.9 in × 109.6 in)" ;
     arp:artworkPeriod "Early Renaissance" ;
     arp:artworkStyle "Renaissance" ;
-    schema:image <https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg/1280px-Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg> ;
-    schema:artMedium aat:300015062 ;  # Tempera
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Sandro_Botticelli_-_La_nascita_di_Venere_-_Google_Art_Project_-_edited.jpg> ;
+    schema:artMedium aat:300015062 ;
     arp:currentOwner arp:owner_italian_state ;
     arp:currentLocation arp:location_uffizi ;
     owl:sameAs dbr:The_Birth_of_Venus, wd:Q81689 ;
@@ -376,6 +553,7 @@ arp:artwork_car_cu_boi a arp:Artwork, schema:VisualArtwork, schema:Painting ;
     arp:artworkStyle "Impressionism, Realism" ;
     arp:currentOwner arp:owner_romanian_state ;
     arp:currentLocation arp:location_mnac ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Nicolae_Grigorescu_-_Car_cu_boi.jpg> ;
     owl:sameAs wd:Q12726936 ;
     arp:hasProvenanceEvent arp:prov_car_001, arp:prov_car_002 .
 
@@ -402,6 +580,7 @@ arp:prov_car_002 a arp:ProvenanceEvent ;
 
 arp:artwork_anemone a arp:Artwork, schema:VisualArtwork, schema:Painting ;
     dc:title "Anemone"@en ;
+    dc:title "Anemone"@ro ;
     dc:creator arp:artist_luchian ;
     dcterms:created "1908"^^xsd:gYear ;
     dc:description "One of Ștefan Luchian's famous flower paintings, showcasing his distinctive style despite being affected by multiple sclerosis."@en ;
@@ -409,8 +588,11 @@ arp:artwork_anemone a arp:Artwork, schema:VisualArtwork, schema:Painting ;
     arp:artworkDimensions "44 cm × 34 cm" ;
     arp:artworkPeriod "Romanian Post-Impressionism" ;
     arp:artworkStyle "Post-Impressionism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Stefan_Luchian_-_Anemone.jpg> ;
+    schema:artMedium aat:300015050 ;
     arp:currentOwner arp:owner_romanian_state ;
     arp:currentLocation arp:location_mnac ;
+    owl:sameAs wd:Q97304909 ;
     arp:hasProvenanceEvent arp:prov_anemone_001, arp:prov_anemone_002, arp:prov_anemone_003 .
 
 # Provenance Events for Anemone
@@ -438,3 +620,385 @@ arp:prov_anemone_003 a arp:ProvenanceEvent ;
     arp:eventLocation arp:location_mnac ;
     arp:provenanceOrder 3 .
 
+# =============================================================================
+# ARTWORK 6: Girl with a Pearl Earring
+# =============================================================================
+
+arp:artwork_girl_pearl_earring a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Girl with a Pearl Earring"@en ;
+    dc:title "Meisje met de parel"@nl ;
+    dc:creator arp:artist_vermeer ;
+    dcterms:created "1665"^^xsd:gYear ;
+    dc:description "An oil painting by Dutch Golden Age painter Johannes Vermeer, depicting a girl wearing an exotic dress and a large pearl earring."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "44.5 cm × 39 cm (17.5 in × 15 in)" ;
+    arp:artworkPeriod "Dutch Golden Age" ;
+    arp:artworkStyle "Baroque, Tronie" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Johannes_Vermeer_-_Girl_with_a_Pearl_Earring_(Mauritshuis).jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_dutch_state ;
+    arp:currentLocation arp:location_mauritshuis ;
+    owl:sameAs dbr:Girl_with_a_Pearl_Earring, wd:Q161764 ;
+    arp:hasProvenanceEvent arp:prov_girl_pearl_001, arp:prov_girl_pearl_002 .
+
+arp:prov_girl_pearl_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Johannes Vermeer painted this work, likely as a 'tronie' (study of a head)."@en ;
+    prov:startedAtTime "1665-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_vermeer ;
+    arp:provenanceOrder 1 .
+
+arp:prov_girl_pearl_002 a arp:ProvenanceEvent ;
+    arp:eventType "Acquisition" ;
+    dc:description "Acquired by the Mauritshuis museum in The Hague."@en ;
+    prov:startedAtTime "1902-01-01"^^xsd:date ;
+    arp:fromOwner arp:owner_private_collectors ;
+    arp:toOwner arp:owner_dutch_state ;
+    arp:eventLocation arp:location_mauritshuis ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 7: The Night Watch
+# =============================================================================
+
+arp:artwork_night_watch a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "The Night Watch"@en ;
+    dc:title "De Nachtwacht"@nl ;
+    dc:creator arp:artist_rembrandt ;
+    dcterms:created "1642"^^xsd:gYear ;
+    dc:description "A group portrait of a militia company by Rembrandt, one of the most famous Dutch Golden Age paintings."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "363 cm × 437 cm (142.9 in × 172.0 in)" ;
+    arp:artworkPeriod "Dutch Golden Age" ;
+    arp:artworkStyle "Baroque" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/The_Night_Watch_-_HD.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_dutch_state ;
+    arp:currentLocation arp:location_rijksmuseum ;
+    owl:sameAs dbr:The_Night_Watch, wd:Q219831 ;
+    arp:hasProvenanceEvent arp:prov_night_watch_001, arp:prov_night_watch_002 .
+
+arp:prov_night_watch_001 a arp:ProvenanceEvent ;
+    arp:eventType "Commission" ;
+    dc:description "Commissioned by Captain Frans Banning Cocq for the Kloveniersdoelen (civic militia headquarters)."@en ;
+    prov:startedAtTime "1642-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_rembrandt ;
+    arp:provenanceOrder 1 .
+
+arp:prov_night_watch_002 a arp:ProvenanceEvent ;
+    arp:eventType "Transfer" ;
+    dc:description "Moved to the Rijksmuseum where it has been on display since 1885."@en ;
+    prov:startedAtTime "1885-01-01"^^xsd:date ;
+    arp:toOwner arp:owner_dutch_state ;
+    arp:eventLocation arp:location_rijksmuseum ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 8: The Scream
+# =============================================================================
+
+arp:artwork_the_scream a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "The Scream"@en ;
+    dc:title "Skrik"@no ;
+    dc:creator arp:artist_munch ;
+    dcterms:created "1893"^^xsd:gYear ;
+    dc:description "An expressionist painting showing a figure with an agonized face against a tumultuous sky, representing the anxiety of modern life."@en ;
+    arp:artworkMedium "Oil, tempera and pastel on cardboard" ;
+    arp:artworkDimensions "91 cm × 73.5 cm (36 in × 28.9 in)" ;
+    arp:artworkPeriod "Expressionism" ;
+    arp:artworkStyle "Expressionism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Edvard_Munch_-_The_Scream_-_Google_Art_Project.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_norwegian_state ;
+    arp:currentLocation arp:location_national_gallery_oslo ;
+    owl:sameAs dbr:The_Scream, wd:Q471379 ;
+    arp:hasProvenanceEvent arp:prov_scream_001, arp:prov_scream_002 .
+
+arp:prov_scream_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Edvard Munch created this work as part of his series 'The Frieze of Life'."@en ;
+    prov:startedAtTime "1893-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_munch ;
+    arp:provenanceOrder 1 .
+
+arp:prov_scream_002 a arp:ProvenanceEvent ;
+    arp:eventType "Donation" ;
+    dc:description "Munch bequeathed his remaining works to the city of Oslo upon his death."@en ;
+    prov:startedAtTime "1944-01-23"^^xsd:date ;
+    arp:fromOwner arp:artist_munch ;
+    arp:toOwner arp:owner_norwegian_state ;
+    arp:eventLocation arp:location_national_gallery_oslo ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 9: Guernica
+# =============================================================================
+
+arp:artwork_guernica a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Guernica"@en ;
+    dc:title "Guernica"@es ;
+    dc:creator arp:artist_picasso ;
+    dcterms:created "1937"^^xsd:gYear ;
+    dc:description "A powerful mural-sized oil painting on canvas showing the brutal realities of war, created by Pablo Picasso as a protest against the Bombing of Guernica during the Spanish Civil War."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "349 cm × 776 cm (137.4 in × 305.5 in)" ;
+    arp:artworkPeriod "Modernism" ;
+    arp:artworkStyle "Cubism" ;
+    schema:image <https://en.wikipedia.org/wiki/Special:FilePath/PicassoGuernica.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_spanish_state ;
+    arp:currentLocation arp:location_reina_sofia ;
+    owl:sameAs dbr:Guernica, wd:Q204857 ;
+    arp:hasProvenanceEvent arp:prov_guernica_001, arp:prov_guernica_002, arp:prov_guernica_003 .
+
+arp:prov_guernica_001 a arp:ProvenanceEvent ;
+    arp:eventType "Commission" ;
+    dc:description "Commissioned by the Spanish Republican government for the Spanish Pavilion at the 1937 Paris International Exposition."@en ;
+    prov:startedAtTime "1937-01-01"^^xsd:date ;
+    prov:endedAtTime "1937-06-04"^^xsd:date ;
+    arp:toOwner arp:artist_picasso ;
+    arp:eventLocation <http://dbpedia.org/resource/Paris> ;
+    arp:provenanceOrder 1 .
+
+arp:prov_guernica_002 a arp:ProvenanceEvent ;
+    arp:eventType "Exile" ;
+    dc:description "Following the Spanish Civil War, the painting was kept outside Spain for many decades during Franco's regime, residing in MoMA's collection."@en ;
+    prov:startedAtTime "1939-01-01"^^xsd:date ;
+    prov:endedAtTime "1981-01-01"^^xsd:date ;
+    arp:fromOwner arp:artist_picasso ;
+    arp:toOwner arp:owner_moma ;
+    arp:eventLocation arp:location_moma ;
+    arp:provenanceOrder 2 .
+
+arp:prov_guernica_003 a arp:ProvenanceEvent ;
+    arp:eventType "Repatriation" ;
+    dc:description "Returned to Spain and installed in the Museo Reina Sofía in Madrid following Franco's death."@en ;
+    prov:startedAtTime "1981-09-10"^^xsd:date ;
+    arp:fromOwner arp:owner_moma ;
+    arp:toOwner arp:owner_spanish_state ;
+    arp:eventLocation arp:location_reina_sofia ;
+    arp:provenanceOrder 3 .
+
+# =============================================================================
+# ARTWORK 10: Water Lilies
+# =============================================================================
+
+arp:artwork_water_lilies a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Water Lilies"@en ;
+    dc:title "Nymphéas"@fr ;
+    dc:creator arp:artist_monet ;
+    dcterms:created "1920"^^xsd:gYear ;
+    arp:creationEndDate "1926"^^xsd:gYear ;
+    dc:description "One of the monumental water lilies murals from Claude Monet's final series, displayed in the Musée de l'Orangerie."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "200 cm × 1275 cm (78.7 in × 502 in)" ;
+    arp:artworkPeriod "Impressionism" ;
+    arp:artworkStyle "Impressionism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Claude_Monet_-_Water_Lilies_-_1906,_Ryerson.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_french_republic ;
+    arp:currentLocation arp:location_musee_orangerie ;
+    owl:sameAs dbr:Water_Lilies, wd:Q155821 ;
+    arp:hasProvenanceEvent arp:prov_water_lilies_001, arp:prov_water_lilies_002 .
+
+arp:prov_water_lilies_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Claude Monet created this work as part of his final monumental water lilies series at Giverny."@en ;
+    prov:startedAtTime "1920-01-01"^^xsd:date ;
+    prov:endedAtTime "1926-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_monet ;
+    arp:provenanceOrder 1 .
+
+arp:prov_water_lilies_002 a arp:ProvenanceEvent ;
+    arp:eventType "Donation" ;
+    dc:description "Donated by Monet to the French state, displayed in specially designed oval rooms in the Orangerie."@en ;
+    prov:startedAtTime "1927-05-17"^^xsd:date ;
+    arp:fromOwner arp:artist_monet ;
+    arp:toOwner arp:owner_french_republic ;
+    arp:eventLocation arp:location_musee_orangerie ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 11: The Kiss (Der Kuss)
+# =============================================================================
+
+arp:artwork_the_kiss a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "The Kiss"@en ;
+    dc:title "Der Kuss"@de ;
+    dc:creator arp:artist_klimt ;
+    dcterms:created "1908"^^xsd:gYear ;
+    dc:description "A golden-hued painting depicting a couple embracing, created by Gustav Klimt during the height of the Vienna Secession movement."@en ;
+    arp:artworkMedium "Oil and gold leaf on canvas" ;
+    arp:artworkDimensions "180 cm × 180 cm (71 in × 71 in)" ;
+    arp:artworkPeriod "Art Nouveau" ;
+    arp:artworkStyle "Vienna Secession, Symbolism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/The_Kiss_-_Gustav_Klimt_-_Google_Cultural_Institute.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_austrian_state ;
+    arp:currentLocation arp:location_belvedere ;
+    owl:sameAs dbr:The_Kiss, wd:Q39629 ;
+    arp:hasProvenanceEvent arp:prov_kiss_001, arp:prov_kiss_002 .
+
+arp:prov_kiss_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Gustav Klimt created this iconic work in Vienna during his most productive period."@en ;
+    prov:startedAtTime "1908-01-01"^^xsd:date ;
+    prov:endedAtTime "1909-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_klimt ;
+    arp:provenanceOrder 1 .
+
+arp:prov_kiss_002 a arp:ProvenanceEvent ;
+    arp:eventType "Collection" ;
+    dc:description "Acquired for the Belvedere collection and remains one of the most valued treasures of Austrian cultural heritage."@en ;
+    prov:startedAtTime "1910-01-01"^^xsd:date ;
+    arp:toOwner arp:owner_austrian_state ;
+    arp:eventLocation arp:location_belvedere ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 12: Safta Florăreasa (The Flower Seller) - Romanian Heritage
+# =============================================================================
+
+arp:artwork_safta_florareasa a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Safta Florăreasa"@ro ;
+    dc:title "The Flower Seller"@en ;
+    dc:creator arp:artist_luchian ;
+    dcterms:created "1901"^^xsd:gYear ;
+    dc:description "An iconic portrait of a Bucharest flower seller by Ștefan Luchian, considered a masterpiece of Romanian painting."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "80.5 cm × 62 cm" ;
+    arp:artworkPeriod "Romanian Post-Impressionism" ;
+    arp:artworkStyle "Post-Impressionism, Realism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Stefan_Luchian_-_Safta_florareasa.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_romanian_state ;
+    arp:currentLocation arp:location_mnac ;
+    owl:sameAs wd:Q18576091 ;
+    arp:hasProvenanceEvent arp:prov_safta_001, arp:prov_safta_002 .
+
+arp:prov_safta_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Ștefan Luchian painted this portrait of a well-known Bucharest flower seller named Safta."@en ;
+    prov:startedAtTime "1901-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_luchian ;
+    arp:provenanceOrder 1 .
+
+arp:prov_safta_002 a arp:ProvenanceEvent ;
+    arp:eventType "National Acquisition" ;
+    dc:description "Acquired for the national collection at the National Museum of Art of Romania."@en ;
+    prov:startedAtTime "1950-01-01"^^xsd:date ;
+    arp:fromOwner arp:owner_romanian_private_collectors ;
+    arp:toOwner arp:owner_romanian_state ;
+    arp:eventLocation arp:location_mnac ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 13: Rodica - Romanian Heritage
+# =============================================================================
+
+arp:artwork_rodica a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Rodica"@ro ;
+    dc:title "Rodica"@en ;
+    dc:creator arp:artist_tonitza ;
+    dcterms:created "1924"^^xsd:gYear ;
+    dc:description "A portrait of a girl named Rodica, exemplifying Nicolae Tonitza's distinctive style of painting children."@en ;
+    arp:artworkMedium "Oil on cardboard" ;
+    arp:artworkDimensions "50.5 cm × 41 cm" ;
+    arp:artworkPeriod "Romanian Expressionism" ;
+    arp:artworkStyle "Expressionism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Nicolae_Tonitza_-_Rodica.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_romanian_state ;
+    arp:currentLocation arp:location_mnac ;
+    owl:sameAs wd:Q50378974 ;
+    arp:hasProvenanceEvent arp:prov_rodica_001, arp:prov_rodica_002 .
+
+arp:prov_rodica_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Nicolae Tonitza painted this characteristic portrait during his prolific period."@en ;
+    prov:startedAtTime "1924-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_tonitza ;
+    arp:provenanceOrder 1 .
+
+arp:prov_rodica_002 a arp:ProvenanceEvent ;
+    arp:eventType "National Acquisition" ;
+    dc:description "Acquired for the National Museum of Art of Romania."@en ;
+    prov:startedAtTime "1950-01-01"^^xsd:date ;
+    arp:fromOwner arp:owner_romanian_private_collectors ;
+    arp:toOwner arp:owner_romanian_state ;
+    arp:eventLocation arp:location_mnac ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 14: Iarna la Barbizon (Winter at Barbizon) - Romanian Heritage
+# =============================================================================
+
+arp:artwork_iarna_barbizon a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Iarna la Barbizon"@ro ;
+    dc:title "Winter at Barbizon"@en ;
+    dc:creator arp:artist_grigorescu ;
+    dcterms:created "1875"^^xsd:gYear ;
+    dc:description "A winter landscape painted by Nicolae Grigorescu during his time at the Barbizon school in France."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "45 cm × 65 cm" ;
+    arp:artworkPeriod "Romanian Impressionism" ;
+    arp:artworkStyle "Impressionism, Barbizon School" ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_romanian_state ;
+    arp:currentLocation arp:location_mnac ;
+    owl:sameAs wd:Q20856523 ;
+    arp:hasProvenanceEvent arp:prov_iarna_001, arp:prov_iarna_002 .
+
+arp:prov_iarna_001 a arp:ProvenanceEvent ;
+    arp:eventType "Creation" ;
+    dc:description "Nicolae Grigorescu painted this during his formative years with the Barbizon school painters in France."@en ;
+    prov:startedAtTime "1875-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_grigorescu ;
+    arp:provenanceOrder 1 .
+
+arp:prov_iarna_002 a arp:ProvenanceEvent ;
+    arp:eventType "National Acquisition" ;
+    dc:description "Acquired for the National Museum of Art of Romania collection."@en ;
+    prov:startedAtTime "1950-01-01"^^xsd:date ;
+    arp:fromOwner arp:owner_romanian_private_collectors ;
+    arp:toOwner arp:owner_romanian_state ;
+    arp:eventLocation arp:location_mnac ;
+    arp:provenanceOrder 2 .
+
+# =============================================================================
+# ARTWORK 15: Bătălia de la Oltenita (Battle of Oltenita) - Romanian Heritage
+# =============================================================================
+
+arp:artwork_battle_oltenita a arp:Artwork, schema:VisualArtwork, schema:Painting ;
+    dc:title "Bătălia de la Oltenita"@ro ;
+    dc:title "Battle of Oltenita"@en ;
+    dc:creator arp:artist_aman ;
+    dcterms:created "1873"^^xsd:gYear ;
+    dc:description "A historical painting depicting the Battle of Oltenita (1853), part of the Crimean War, showcasing Theodor Aman's skill in historical scene composition."@en ;
+    arp:artworkMedium "Oil on canvas" ;
+    arp:artworkDimensions "197 cm × 279 cm" ;
+    arp:artworkPeriod "Romanian Romanticism" ;
+    arp:artworkStyle "Romanticism, Realism" ;
+    schema:image <https://commons.wikimedia.org/wiki/Special:FilePath/Theodor_Aman_-_Battle_of_Oltenita.jpg> ;
+    schema:artMedium aat:300015050 ;
+    arp:currentOwner arp:owner_romanian_state ;
+    arp:currentLocation arp:location_mnac ;
+    owl:sameAs wd:Q19636451 ;
+    arp:hasProvenanceEvent arp:prov_battle_001, arp:prov_battle_002 .
+
+arp:prov_battle_001 a arp:ProvenanceEvent ;
+    arp:eventType "Commission" ;
+    dc:description "Commissioned to commemorate the Romanian participation in the Russo-Turkish conflict."@en ;
+    prov:startedAtTime "1873-01-01"^^xsd:date ;
+    arp:toOwner arp:artist_aman ;
+    arp:provenanceOrder 1 .
+
+arp:prov_battle_002 a arp:ProvenanceEvent ;
+    arp:eventType "National Collection" ;
+    dc:description "Part of the National Museum of Art of Romania's collection commemorating Romanian military history."@en ;
+    prov:startedAtTime "1950-01-01"^^xsd:date ;
+    arp:toOwner arp:owner_romanian_state ;
+    arp:eventLocation arp:location_mnac ;
+    arp:provenanceOrder 2 .
+
+# END OF FILE


### PR DESCRIPTION
SPARQL Deduplication:
- Fix SPARQL queries to prefer English titles, preventing duplicate entries for artworks with multi-language titles (e.g., Mona Lisa/La Gioconda)
- Apply language filter to count queries to ensure accurate pagination

Image Performance:
- Create OptimizedImage component with global caching and lazy loading
- Convert Wikimedia Commons URLs to use thumbnails (?width=) for faster loads
- Add loading skeleton with smooth fade-in animation
- Preload higher-res images on card hover for faster detail page loads
- Add shrinkOnLoad prop to control container sizing behavior

Artist Information:
- Add LocalArtistInfo model to use TTL data as fallback
- Update enrichment endpoint to fetch local artist data (name, birth/death dates, nationality, description)
- Display local artist info when external sources (DBpedia/Wikidata) unavailable
- Show full formatted dates (e.g., "May 15, 1838") instead of just years
- Add explicit "Born:" and "Died:" labels for clarity

UI Improvements:
- Add CSS containment rules to improve scroll performance
- Make detail page image card shrink to match image dimensions
- Keep grid card images filling their aspect-ratio containers
- Memoize ArtworkCard component to prevent unnecessary re-renders

Closes #9