### PR TITLE
feat(frontend): Add SPARQL Explorer page with query editor and export

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-sql": "^6.10.0",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@uiw/react-codemirror": "^4.25.4",
         "axios": "^1.13.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -265,6 +268,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -311,6 +323,114 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.1.tgz",
+      "integrity": "sha512-uWDWFypNdQmz2y1LaNJzK7fL7TYKLeUAU0npEC685OKTF3KcQ2Vu3klIM78D7I6wGhktme0lh3CuQLv0ZCrD9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
+      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
+      "integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.3.tgz",
+      "integrity": "sha512-MerMzJzlXogk2fxWFU1nKp36bY5orBG59HnPiz0G9nLRebWa0zXuv2siH6PLIHBvv5TH8CkQRqjBs0MlxCZu+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.39.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.9.tgz",
+      "integrity": "sha512-miGSIfBOKC1s2oHoa80dp+BjtsL8sXsrgGlQnQuOcfvaedcQUtqddTmKbJSDkLl4mkgPvZyXuKic2HDNYcJLYA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1013,6 +1133,36 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.0.tgz",
+      "integrity": "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.7.tgz",
+      "integrity": "sha512-wNIFWdSUfX9Jc6ePMzxSPVgTVB4EOfDIwLQLWASyiUdHKaMsiilj9bYiGkGQCKVodd0x6bgQCV207PILGFCF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
@@ -1962,6 +2112,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.4.tgz",
+      "integrity": "sha512-YzNwkm0AbPv1EXhCHYR5v0nqfemG2jEB0Z3Att4rBYqKrlG7AA9Rhjc3IyBaOzsBu18wtrp9/+uhTyu7TXSRng==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.4.tgz",
+      "integrity": "sha512-ipO067oyfUw+DVaXhQCxkB0ZD9b7RnY+ByrprSYSKCHaULvJ3sqWYC/Zen6zVQ8/XC4o5EPBfatGiX20kC7XGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.4",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
@@ -2188,6 +2391,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2246,6 +2464,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3024,7 +3248,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3126,7 +3349,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -3858,6 +4080,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4097,6 +4325,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@uiw/react-codemirror": "^4.25.4",
     "axios": "^1.13.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,7 +17,8 @@
   --color-bronze-light: #a69076;
 
   /* Typography */
-  --font-heading: "Cormorant Garamond", "Palatino Linotype", "Book Antiqua", serif;
+  --font-heading: "Cormorant Garamond", "Palatino Linotype", "Book Antiqua",
+    serif;
   --font-body: "Nunito Sans", "Segoe UI", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "Fira Code", monospace;
 }
@@ -35,7 +36,12 @@ body {
   margin: 0;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-heading);
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -84,4 +90,69 @@ img {
 /* Improve scrolling performance */
 .grid {
   contain: layout style;
+}
+
+/* Animation utilities */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-from-top {
+  from {
+    transform: translateY(-8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-from-bottom {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.animate-in {
+  animation-duration: 300ms;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.fade-in {
+  animation-name: fade-in;
+}
+
+.slide-in-from-top-2 {
+  animation-name: slide-in-from-top;
+}
+
+.slide-in-from-bottom-2 {
+  animation-name: slide-in-from-bottom;
+}
+
+/* Line clamp utility */
+.line-clamp-1 {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/frontend/src/pages/SPARQLPage.tsx
+++ b/frontend/src/pages/SPARQLPage.tsx
@@ -1,51 +1,191 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { sql } from "@codemirror/lang-sql";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { sparqlApi } from "../services/api";
 
+// Example queries for the SPARQL explorer - matching the ArP ontology
 const exampleQueries = [
   {
-    name: 'List all artworks',
-    query: `PREFIX schema: <https://schema.org/>
+    name: "List all artworks",
+    description: "Retrieve all artworks with their titles and artist names",
+    category: "Basic",
+    query: `PREFIX arp: <http://example.org/arp#>
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX schema: <http://schema.org/>
 
-SELECT ?artwork ?title ?artist
+SELECT ?artwork ?title ?artistName
 WHERE {
-  ?artwork a schema:VisualArtwork ;
+  ?artwork a arp:Artwork ;
            dc:title ?title ;
            dc:creator ?artist .
+  ?artist schema:name ?artistName .
 }
 LIMIT 20`,
   },
   {
-    name: 'Artworks by artist',
-    query: `PREFIX schema: <https://schema.org/>
+    name: "Artworks by Van Gogh",
+    description: "Find all artworks created by Vincent van Gogh",
+    category: "Basic",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+
+SELECT ?artwork ?title ?dateCreated ?medium
+WHERE {
+  ?artwork a arp:Artwork ;
+           dc:title ?title ;
+           dc:creator ?artist .
+  ?artist schema:name "Vincent van Gogh"@en .
+  OPTIONAL { ?artwork dcterms:created ?dateCreated }
+  OPTIONAL { ?artwork arp:artworkMedium ?medium }
+}`,
+  },
+  {
+    name: "All artists",
+    description: "List all artists with their birth/death dates",
+    category: "Basic",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX schema: <http://schema.org/>
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
 
-SELECT ?artwork ?title ?dateCreated
+SELECT ?artist ?name ?birthDate ?deathDate ?nationality
 WHERE {
-  ?artwork a schema:VisualArtwork ;
-           dc:title ?title ;
-           dc:creator "Vincent van Gogh" ;
-           dc:date ?dateCreated .
+  ?artist a arp:Artist ;
+          schema:name ?name .
+  OPTIONAL { ?artist schema:birthDate ?birthDate }
+  OPTIONAL { ?artist schema:deathDate ?deathDate }
+  OPTIONAL { ?artist schema:nationality ?nationality }
 }
-ORDER BY ?dateCreated`,
+ORDER BY ?name`,
   },
   {
-    name: 'Provenance events',
-    query: `PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX schema: <https://schema.org/>
+    name: "Provenance events",
+    description: "Track provenance events for artworks",
+    category: "Provenance",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX schema: <http://schema.org/>
 
-SELECT ?artwork ?event ?date ?owner
+SELECT ?title ?eventType ?startDate ?toOwnerName
 WHERE {
-  ?artwork a schema:VisualArtwork .
-  ?event prov:used ?artwork ;
-         prov:atTime ?date ;
-         prov:wasAssociatedWith ?owner .
+  ?artwork a arp:Artwork ;
+           dc:title ?title ;
+           arp:hasProvenanceEvent ?event .
+  ?event arp:eventType ?eventType ;
+         prov:startedAtTime ?startDate .
+  OPTIONAL { 
+    ?event arp:toOwner ?toOwner .
+    ?toOwner schema:name ?toOwnerName .
+  }
 }
-ORDER BY ?date`,
+ORDER BY ?title ?startDate`,
   },
   {
-    name: 'Artworks from DBpedia',
+    name: "Ownership chain",
+    description: "Get complete ownership history for a specific artwork",
+    category: "Provenance",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX schema: <http://schema.org/>
+
+SELECT ?eventType ?description ?startDate ?fromOwnerName ?toOwnerName ?locationName
+WHERE {
+  ?artwork dc:title "Mona Lisa"@en ;
+           arp:hasProvenanceEvent ?event .
+  ?event arp:eventType ?eventType ;
+         dc:description ?description ;
+         prov:startedAtTime ?startDate .
+  OPTIONAL { 
+    ?event arp:fromOwner ?fromOwner .
+    ?fromOwner schema:name ?fromOwnerName .
+  }
+  OPTIONAL { 
+    ?event arp:toOwner ?toOwner .
+    ?toOwner schema:name ?toOwnerName .
+  }
+  OPTIONAL { 
+    ?event arp:eventLocation ?location .
+    ?location schema:name ?locationName .
+  }
+}
+ORDER BY ?startDate`,
+  },
+  {
+    name: "Artworks by period",
+    description: "Group artworks by art historical period",
+    category: "Analytics",
+    query: `PREFIX arp: <http://example.org/arp#>
+
+SELECT ?period (COUNT(?artwork) as ?count)
+WHERE {
+  ?artwork a arp:Artwork ;
+           arp:artworkPeriod ?period .
+}
+GROUP BY ?period
+ORDER BY DESC(?count)`,
+  },
+  {
+    name: "Artworks by current location",
+    description: "Find artworks grouped by museum/location",
+    category: "Analytics",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX schema: <http://schema.org/>
+
+SELECT ?locationName (COUNT(?artwork) as ?artworkCount)
+WHERE {
+  ?artwork a arp:Artwork ;
+           arp:currentLocation ?location .
+  ?location schema:name ?locationName .
+}
+GROUP BY ?locationName
+ORDER BY DESC(?artworkCount)`,
+  },
+  {
+    name: "Museums and their artworks",
+    description: "List all museums with the artworks they hold",
+    category: "Basic",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX schema: <http://schema.org/>
+
+SELECT ?museumName ?title ?artistName
+WHERE {
+  ?artwork a arp:Artwork ;
+           dc:title ?title ;
+           dc:creator ?artist ;
+           arp:currentLocation ?museum .
+  ?artist schema:name ?artistName .
+  ?museum a schema:Museum ;
+          schema:name ?museumName .
+}
+ORDER BY ?museumName ?title`,
+  },
+  {
+    name: "Artworks with external links",
+    description: "Find artworks linked to DBpedia and Wikidata",
+    category: "Linked Data",
+    query: `PREFIX arp: <http://example.org/arp#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+SELECT ?title ?sameAsLink
+WHERE {
+  ?artwork a arp:Artwork ;
+           dc:title ?title ;
+           owl:sameAs ?sameAsLink .
+}
+ORDER BY ?title`,
+  },
+  {
+    name: "DBpedia federated query",
+    description: "Federated query to retrieve artwork data from DBpedia",
+    category: "Federated",
     query: `PREFIX dbo: <http://dbpedia.org/ontology/>
-PREFIX dbp: <http://dbpedia.org/property/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?artwork ?title ?artist ?museum
@@ -66,142 +206,458 @@ LIMIT 10`,
   },
 ];
 
+interface SPARQLResult {
+  head: { vars: string[] };
+  results: { bindings: Record<string, { type: string; value: string }>[] };
+}
+
+interface ConnectionStatus {
+  connected: boolean;
+  checking: boolean;
+}
+
 const SPARQLPage = () => {
   const [query, setQuery] = useState(exampleQueries[0].query);
-  const [results, setResults] = useState<null | { head: { vars: string[] }; results: { bindings: Record<string, { value: string }>[] } }>(null);
+  const [results, setResults] = useState<SPARQLResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [executionTime, setExecutionTime] = useState<number | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string>("All");
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({
+    connected: false,
+    checking: true,
+  });
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-  // Cleanup timeout on unmount
+  // Get unique categories
+  const categories = [
+    "All",
+    ...Array.from(new Set(exampleQueries.map((q) => q.category))),
+  ];
+
+  // Filter queries by category
+  const filteredQueries =
+    selectedCategory === "All"
+      ? exampleQueries
+      : exampleQueries.filter((q) => q.category === selectedCategory);
+
+  // Check Fuseki connection status on mount
+  useEffect(() => {
+    const checkConnection = async () => {
+      try {
+        const response = await fetch(
+          `${
+            import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api"
+          }/sparql/status`
+        );
+        const data = await response.json();
+        setConnectionStatus({ connected: data.connected, checking: false });
+      } catch {
+        setConnectionStatus({ connected: false, checking: false });
+      }
+    };
+    checkConnection();
+  }, []);
+
+  // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
       }
     };
   }, []);
 
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "Enter") {
+        e.preventDefault();
+        if (query.trim() && !isLoading) {
+          handleExecuteQuery();
+        }
+      } else if (e.ctrlKey && e.key === "l") {
+        e.preventDefault();
+        handleClear();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [query, isLoading]);
+
   const handleExecuteQuery = async () => {
-    // Clear any pending timeout
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
+    // Cancel any pending request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
     }
+    abortControllerRef.current = new AbortController();
 
     setIsLoading(true);
     setError(null);
     setResults(null);
+    setExecutionTime(null);
 
-    // Simulated response for demo purposes
-    timeoutRef.current = setTimeout(() => {
-      setResults({
-        head: { vars: ['artwork', 'title', 'artist'] },
-        results: {
-          bindings: [
-            { artwork: { value: 'http://arp.example.org/artwork/1' }, title: { value: 'The Starry Night' }, artist: { value: 'Vincent van Gogh' } },
-            { artwork: { value: 'http://arp.example.org/artwork/2' }, title: { value: 'Mona Lisa' }, artist: { value: 'Leonardo da Vinci' } },
-            { artwork: { value: 'http://arp.example.org/artwork/3' }, title: { value: 'The Persistence of Memory' }, artist: { value: 'Salvador Dalí' } },
-          ],
-        },
-      });
+    const startTime = performance.now();
+
+    try {
+      const response = await sparqlApi.query(query);
+      const endTime = performance.now();
+      setExecutionTime(Math.round(endTime - startTime));
+
+      if (response.data.success) {
+        setResults(response.data.results as SPARQLResult);
+      } else {
+        setError(response.data.error || "Query execution failed");
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name !== "AbortError") {
+        setError(
+          err.message ||
+            "Failed to execute query. Please check your query syntax and try again."
+        );
+      }
+    } finally {
       setIsLoading(false);
-    }, 1000);
+    }
   };
 
   const handleSelectExample = (exampleQuery: string) => {
     setQuery(exampleQuery);
     setResults(null);
     setError(null);
+    setExecutionTime(null);
   };
+
+  const handleClear = () => {
+    setQuery("");
+    setResults(null);
+    setError(null);
+    setExecutionTime(null);
+  };
+
+  // Export functions
+  const exportToCSV = useCallback(() => {
+    if (!results) return;
+
+    const headers = results.head.vars;
+    const rows = results.results.bindings.map((binding) =>
+      headers.map((h) => {
+        const value = binding[h]?.value || "";
+        // Escape quotes and wrap in quotes if contains comma or quote
+        if (
+          value.includes(",") ||
+          value.includes('"') ||
+          value.includes("\n")
+        ) {
+          return `"${value.replace(/"/g, '""')}"`;
+        }
+        return value;
+      })
+    );
+
+    const csv = [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(blob);
+    link.download = `sparql_results_${
+      new Date().toISOString().split("T")[0]
+    }.csv`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }, [results]);
+
+  const exportToJSON = useCallback(() => {
+    if (!results) return;
+
+    // Transform to cleaner format
+    const data = results.results.bindings.map((binding) => {
+      const row: Record<string, string> = {};
+      results.head.vars.forEach((v) => {
+        row[v] = binding[v]?.value || "";
+      });
+      return row;
+    });
+
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(blob);
+    link.download = `sparql_results_${
+      new Date().toISOString().split("T")[0]
+    }.json`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }, [results]);
+
+  // Copy query to clipboard
+  const copyQuery = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(query);
+    } catch {
+      console.error("Failed to copy query");
+    }
+  }, [query]);
 
   return (
     <div className="min-h-screen bg-parchment">
       {/* Page Header */}
-      <div className="border-b border-bronze/20 bg-ivory">
+      <div className="border-b border-bronze/20 bg-gradient-to-r from-ivory to-parchment">
         <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
-          <h1 className="font-heading text-3xl font-bold text-charcoal sm:text-4xl">
-            SPARQL Explorer
-          </h1>
-          <p className="mt-4 max-w-2xl text-lg text-charcoal-light">
-            Query the ArP knowledge graph using SPARQL. Execute queries against our 
-            triplestore or federate with DBpedia and Wikidata.
-          </p>
+          <div className="flex items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-gold to-gold-dark shadow-lg">
+              <svg
+                className="h-7 w-7 text-charcoal"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                />
+              </svg>
+            </div>
+            <div>
+              <h1 className="font-heading text-3xl font-bold text-charcoal sm:text-4xl">
+                SPARQL Explorer
+              </h1>
+              <p className="mt-1 text-lg text-charcoal-light">
+                Query the ArP knowledge graph using SPARQL
+              </p>
+            </div>
+          </div>
+
+          {/* Connection Status Badge */}
+          <div className="mt-6 flex items-center gap-3">
+            <div
+              className={`inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium ${
+                connectionStatus.checking
+                  ? "bg-bronze/10 text-bronze"
+                  : connectionStatus.connected
+                  ? "bg-green-100 text-green-700"
+                  : "bg-red-100 text-red-700"
+              }`}
+            >
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  connectionStatus.checking
+                    ? "bg-bronze animate-pulse"
+                    : connectionStatus.connected
+                    ? "bg-green-500"
+                    : "bg-red-500"
+                }`}
+              />
+              {connectionStatus.checking
+                ? "Checking connection..."
+                : connectionStatus.connected
+                ? "Fuseki Connected"
+                : "Fuseki Offline"}
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="grid gap-8 lg:grid-cols-4">
           {/* Sidebar with example queries */}
-          <div className="lg:col-span-1">
-            <h2 className="font-heading text-lg font-semibold text-charcoal">
-              Example Queries
-            </h2>
-            <div className="mt-4 space-y-2">
-              {exampleQueries.map((example, index) => (
-                <button
-                  key={index}
-                  onClick={() => handleSelectExample(example.query)}
-                  className="w-full rounded-lg border border-bronze/20 bg-ivory px-4 py-3 text-left text-sm font-medium text-charcoal transition-colors hover:border-gold hover:bg-gold/5"
-                >
-                  {example.name}
-                </button>
-              ))}
+          <div className="lg:col-span-1 space-y-6">
+            {/* Category Filter */}
+            <div>
+              <h2 className="font-heading text-lg font-semibold text-charcoal mb-3">
+                Query Categories
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {categories.map((category) => (
+                  <button
+                    key={category}
+                    onClick={() => setSelectedCategory(category)}
+                    className={`rounded-full px-3 py-1.5 text-xs font-medium transition-all ${
+                      selectedCategory === category
+                        ? "bg-gradient-to-r from-gold to-gold-dark text-charcoal shadow-md"
+                        : "bg-ivory border border-bronze/20 text-charcoal-light hover:border-gold hover:text-charcoal"
+                    }`}
+                  >
+                    {category}
+                  </button>
+                ))}
+              </div>
             </div>
 
-            <div className="mt-8">
-              <h2 className="font-heading text-lg font-semibold text-charcoal">
-                Endpoints
+            {/* Example Queries */}
+            <div>
+              <h2 className="font-heading text-lg font-semibold text-charcoal mb-3">
+                Example Queries
               </h2>
-              <div className="mt-4 space-y-3 text-sm">
+              <div className="space-y-2 max-h-[400px] overflow-y-auto pr-2">
+                {filteredQueries.map((example, index) => (
+                  <button
+                    key={index}
+                    onClick={() => handleSelectExample(example.query)}
+                    className="w-full rounded-xl border border-bronze/20 bg-ivory p-4 text-left transition-all hover:border-gold hover:shadow-md hover:bg-gold/5 group"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="text-sm font-semibold text-charcoal group-hover:text-gold-dark">
+                        {example.name}
+                      </span>
+                      <span className="shrink-0 rounded-full bg-parchment-dark/50 px-2 py-0.5 text-xs text-charcoal-light">
+                        {example.category}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-charcoal-light line-clamp-2">
+                      {example.description}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Endpoints Reference */}
+            <div className="rounded-xl border border-bronze/20 bg-ivory p-5">
+              <h2 className="font-heading text-lg font-semibold text-charcoal mb-4">
+                SPARQL Endpoints
+              </h2>
+              <div className="space-y-4">
                 <div>
-                  <p className="font-medium text-charcoal">ArP Endpoint</p>
-                  <p className="text-charcoal-light">http://localhost:3030/arp/sparql</p>
+                  <p className="text-xs font-semibold text-gold-dark uppercase tracking-wide">
+                    ArP Triplestore
+                  </p>
+                  <code className="mt-1 block text-xs text-charcoal-light bg-charcoal/5 rounded px-2 py-1 break-all">
+                    http://localhost:3030/arp/sparql
+                  </code>
                 </div>
                 <div>
-                  <p className="font-medium text-charcoal">DBpedia</p>
-                  <p className="text-charcoal-light">http://dbpedia.org/sparql</p>
+                  <p className="text-xs font-semibold text-gold-dark uppercase tracking-wide">
+                    DBpedia
+                  </p>
+                  <code className="mt-1 block text-xs text-charcoal-light bg-charcoal/5 rounded px-2 py-1 break-all">
+                    http://dbpedia.org/sparql
+                  </code>
                 </div>
                 <div>
-                  <p className="font-medium text-charcoal">Wikidata</p>
-                  <p className="text-charcoal-light">https://query.wikidata.org/sparql</p>
+                  <p className="text-xs font-semibold text-gold-dark uppercase tracking-wide">
+                    Wikidata
+                  </p>
+                  <code className="mt-1 block text-xs text-charcoal-light bg-charcoal/5 rounded px-2 py-1 break-all">
+                    https://query.wikidata.org/sparql
+                  </code>
+                </div>
+              </div>
+            </div>
+
+            {/* Keyboard Shortcuts */}
+            <div className="rounded-xl border border-bronze/20 bg-ivory p-5">
+              <h2 className="font-heading text-lg font-semibold text-charcoal mb-3">
+                Shortcuts
+              </h2>
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-charcoal-light">Execute Query</span>
+                  <kbd className="rounded bg-charcoal/10 px-2 py-0.5 text-xs font-mono">
+                    Ctrl + Enter
+                  </kbd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-charcoal-light">Clear Editor</span>
+                  <kbd className="rounded bg-charcoal/10 px-2 py-0.5 text-xs font-mono">
+                    Ctrl + L
+                  </kbd>
                 </div>
               </div>
             </div>
           </div>
 
           {/* Main query area */}
-          <div className="lg:col-span-3">
+          <div className="lg:col-span-3 space-y-6">
             {/* Query Editor */}
-            <div className="rounded-2xl border border-bronze/20 bg-ivory shadow-sm">
-              <div className="flex items-center justify-between border-b border-bronze/10 px-6 py-4">
-                <h2 className="font-heading text-lg font-semibold text-charcoal">
-                  Query Editor
-                </h2>
+            <div className="rounded-2xl border border-bronze/20 bg-ivory shadow-lg overflow-hidden">
+              <div className="flex items-center justify-between border-b border-bronze/10 px-6 py-4 bg-gradient-to-r from-charcoal/5 to-transparent">
+                <div className="flex items-center gap-3">
+                  <h2 className="font-heading text-lg font-semibold text-charcoal">
+                    Query Editor
+                  </h2>
+                  <span className="rounded-full bg-charcoal/10 px-2 py-0.5 text-xs text-charcoal-light font-mono">
+                    SPARQL 1.1
+                  </span>
+                </div>
                 <div className="flex gap-2">
                   <button
-                    onClick={() => setQuery('')}
-                    className="rounded-lg border border-bronze/30 px-4 py-2 text-sm text-charcoal-light hover:border-burgundy hover:text-burgundy transition-colors"
+                    onClick={copyQuery}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-bronze/30 px-3 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-all"
+                    title="Copy query"
+                  >
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      />
+                    </svg>
+                    Copy
+                  </button>
+                  <button
+                    onClick={handleClear}
+                    className="rounded-lg border border-bronze/30 px-4 py-2 text-sm text-charcoal-light hover:border-burgundy hover:text-burgundy transition-all"
                   >
                     Clear
                   </button>
                   <button
                     onClick={handleExecuteQuery}
                     disabled={isLoading || !query.trim()}
-                    className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-gold to-gold-dark px-6 py-2 font-medium text-charcoal shadow-md hover:shadow-lg transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-gold to-gold-dark px-6 py-2 font-medium text-charcoal shadow-md hover:shadow-lg hover:scale-[1.02] transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
                   >
                     {isLoading ? (
                       <>
-                        <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                        <svg
+                          className="h-4 w-4 animate-spin"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          />
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          />
                         </svg>
                         Executing...
                       </>
                     ) : (
                       <>
-                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        <svg
+                          className="h-4 w-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                          />
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
                         </svg>
                         Execute
                       </>
@@ -210,25 +666,63 @@ const SPARQLPage = () => {
                 </div>
               </div>
               <div className="p-4">
-                <textarea
+                <CodeMirror
                   value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  className="w-full h-64 rounded-lg border border-bronze/20 bg-charcoal p-4 font-mono text-sm text-parchment focus:border-gold focus:outline-none focus:ring-1 focus:ring-gold"
-                  placeholder="Enter your SPARQL query here..."
-                  spellCheck={false}
+                  height="280px"
+                  theme={oneDark}
+                  extensions={[sql()]}
+                  onChange={(value) => setQuery(value)}
+                  className="rounded-lg overflow-hidden border border-bronze/10"
+                  basicSetup={{
+                    lineNumbers: true,
+                    highlightActiveLineGutter: true,
+                    highlightSpecialChars: true,
+                    foldGutter: true,
+                    drawSelection: true,
+                    dropCursor: true,
+                    allowMultipleSelections: true,
+                    indentOnInput: true,
+                    syntaxHighlighting: true,
+                    bracketMatching: true,
+                    closeBrackets: true,
+                    autocompletion: true,
+                    rectangularSelection: true,
+                    crosshairCursor: false,
+                    highlightActiveLine: true,
+                    highlightSelectionMatches: true,
+                    closeBracketsKeymap: true,
+                    defaultKeymap: true,
+                    searchKeymap: true,
+                    historyKeymap: true,
+                    foldKeymap: true,
+                    completionKeymap: true,
+                    lintKeymap: true,
+                  }}
                 />
               </div>
             </div>
 
             {/* Error Message */}
             {error && (
-              <div className="mt-6 rounded-xl border border-burgundy/30 bg-burgundy/10 p-4">
+              <div className="rounded-xl border border-burgundy/30 bg-gradient-to-r from-burgundy/10 to-burgundy/5 p-5 animate-in fade-in slide-in-from-top-2">
                 <div className="flex items-start gap-3">
-                  <svg className="h-5 w-5 text-burgundy flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-burgundy/20">
+                    <svg
+                      className="h-5 w-5 text-burgundy"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  </div>
                   <div>
-                    <p className="font-medium text-burgundy">Query Error</p>
+                    <p className="font-semibold text-burgundy">Query Error</p>
                     <p className="mt-1 text-sm text-burgundy-dark">{error}</p>
                   </div>
                 </div>
@@ -237,60 +731,228 @@ const SPARQLPage = () => {
 
             {/* Results */}
             {results && (
-              <div className="mt-6 rounded-2xl border border-bronze/20 bg-ivory shadow-sm">
-                <div className="flex items-center justify-between border-b border-bronze/10 px-6 py-4">
-                  <h2 className="font-heading text-lg font-semibold text-charcoal">
-                    Results ({results.results.bindings.length} rows)
-                  </h2>
+              <div className="rounded-2xl border border-bronze/20 bg-ivory shadow-lg overflow-hidden animate-in fade-in slide-in-from-bottom-2">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-bronze/10 px-6 py-4 bg-gradient-to-r from-green-50/50 to-transparent">
+                  <div className="flex items-center gap-4">
+                    <h2 className="font-heading text-lg font-semibold text-charcoal">
+                      Results
+                    </h2>
+                    <div className="flex items-center gap-3 text-sm text-charcoal-light">
+                      <span className="inline-flex items-center gap-1.5">
+                        <svg
+                          className="h-4 w-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
+                          />
+                        </svg>
+                        {results.results.bindings.length} rows
+                      </span>
+                      {executionTime !== null && (
+                        <span className="inline-flex items-center gap-1.5">
+                          <svg
+                            className="h-4 w-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                          </svg>
+                          {executionTime}ms
+                        </span>
+                      )}
+                    </div>
+                  </div>
                   <div className="flex gap-2">
-                    <button className="rounded-lg border border-bronze/30 px-4 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-colors">
+                    <button
+                      onClick={exportToCSV}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-bronze/30 px-4 py-2 text-sm font-medium text-charcoal-light hover:border-gold hover:text-charcoal transition-all hover:shadow-sm"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                        />
+                      </svg>
                       Export CSV
                     </button>
-                    <button className="rounded-lg border border-bronze/30 px-4 py-2 text-sm text-charcoal-light hover:border-gold hover:text-charcoal transition-colors">
+                    <button
+                      onClick={exportToJSON}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-bronze/30 px-4 py-2 text-sm font-medium text-charcoal-light hover:border-gold hover:text-charcoal transition-all hover:shadow-sm"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                        />
+                      </svg>
                       Export JSON
                     </button>
                   </div>
                 </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b border-bronze/10 bg-parchment-dark/30">
-                        {results.head.vars.map((varName) => (
-                          <th
-                            key={varName}
-                            className="px-6 py-3 text-left text-sm font-semibold text-charcoal"
-                          >
-                            ?{varName}
+
+                {results.results.bindings.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-16 text-center">
+                    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-bronze/10">
+                      <svg
+                        className="h-8 w-8 text-bronze"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+                        />
+                      </svg>
+                    </div>
+                    <p className="mt-4 text-lg font-medium text-charcoal">
+                      No results found
+                    </p>
+                    <p className="mt-1 text-sm text-charcoal-light">
+                      The query executed successfully but returned no matching
+                      data.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full">
+                      <thead>
+                        <tr className="border-b border-bronze/10 bg-parchment-dark/30">
+                          <th className="px-4 py-3 text-left text-xs font-semibold text-charcoal-light uppercase tracking-wide">
+                            #
                           </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-bronze/10">
-                      {results.results.bindings.map((binding, rowIndex) => (
-                        <tr key={rowIndex} className="hover:bg-parchment-dark/20">
                           {results.head.vars.map((varName) => (
-                            <td
+                            <th
                               key={varName}
-                              className="px-6 py-4 text-sm text-charcoal-light"
+                              className="px-4 py-3 text-left text-xs font-semibold text-charcoal-light uppercase tracking-wide"
                             >
-                              {binding[varName]?.value?.startsWith('http') ? (
-                                <a
-                                  href={binding[varName]?.value}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="text-gold hover:underline"
-                                >
-                                  {binding[varName]?.value}
-                                </a>
-                              ) : (
-                                binding[varName]?.value || '-'
-                              )}
-                            </td>
+                              ?{varName}
+                            </th>
                           ))}
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody className="divide-y divide-bronze/10">
+                        {results.results.bindings.map((binding, rowIndex) => (
+                          <tr
+                            key={rowIndex}
+                            className="hover:bg-gold/5 transition-colors"
+                          >
+                            <td className="px-4 py-3 text-xs text-charcoal-light font-mono">
+                              {rowIndex + 1}
+                            </td>
+                            {results.head.vars.map((varName) => (
+                              <td
+                                key={varName}
+                                className="px-4 py-3 text-sm text-charcoal-light max-w-md"
+                              >
+                                {binding[varName]?.value?.startsWith("http") ? (
+                                  <a
+                                    href={binding[varName]?.value}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center gap-1 text-gold-dark hover:text-gold hover:underline break-all"
+                                  >
+                                    <span className="line-clamp-1">
+                                      {binding[varName]?.value}
+                                    </span>
+                                    <svg
+                                      className="h-3 w-3 shrink-0"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                      />
+                                    </svg>
+                                  </a>
+                                ) : (
+                                  <span className="break-words">
+                                    {binding[varName]?.value || (
+                                      <span className="text-charcoal-light/50 italic">
+                                        null
+                                      </span>
+                                    )}
+                                  </span>
+                                )}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Empty State */}
+            {!results && !error && !isLoading && (
+              <div className="rounded-2xl border-2 border-dashed border-bronze/30 bg-ivory/50 p-12">
+                <div className="flex flex-col items-center justify-center text-center">
+                  <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-gold/20 to-gold-dark/20">
+                    <svg
+                      className="h-10 w-10 text-gold-dark"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                      />
+                    </svg>
+                  </div>
+                  <h3 className="mt-6 font-heading text-xl font-semibold text-charcoal">
+                    Ready to Query
+                  </h3>
+                  <p className="mt-2 max-w-sm text-charcoal-light">
+                    Write your SPARQL query in the editor above or select one of
+                    the example queries from the sidebar to get started.
+                  </p>
+                  <div className="mt-6 flex items-center gap-2 text-sm text-charcoal-light">
+                    <kbd className="rounded bg-charcoal/10 px-2 py-1 font-mono text-xs">
+                      Ctrl
+                    </kbd>
+                    <span>+</span>
+                    <kbd className="rounded bg-charcoal/10 px-2 py-1 font-mono text-xs">
+                      Enter
+                    </kbd>
+                    <span className="ml-1">to execute</span>
+                  </div>
                 </div>
               </div>
             )}
@@ -302,4 +964,3 @@ const SPARQLPage = () => {
 };
 
 export default SPARQLPage;
-

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,15 +1,20 @@
-import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
+import axios, {
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type AxiosResponse,
+} from "axios";
 
 // API Configuration
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
 
 // Create axios instance with default config
 const apiClient: AxiosInstance = axios.create({
   baseURL: API_BASE_URL,
   timeout: 30000,
   headers: {
-    'Content-Type': 'application/json',
-    'Accept': 'application/json',
+    "Content-Type": "application/json",
+    Accept: "application/json",
   },
 });
 
@@ -34,13 +39,13 @@ apiClient.interceptors.response.use(
   (error) => {
     if (error.response) {
       // Server responded with error status
-      console.error('API Error:', error.response.status, error.response.data);
+      console.error("API Error:", error.response.status, error.response.data);
     } else if (error.request) {
       // Request was made but no response received
-      console.error('Network Error:', error.message);
+      console.error("Network Error:", error.message);
     } else {
       // Error in request setup
-      console.error('Request Error:', error.message);
+      console.error("Request Error:", error.message);
     }
     return Promise.reject(error);
   }
@@ -48,70 +53,83 @@ apiClient.interceptors.response.use(
 
 // Generic API methods
 export const api = {
-  get: <T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> => 
-    apiClient.get<T>(url, config),
-  
-  post: <T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> => 
-    apiClient.post<T>(url, data, config),
-  
-  put: <T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> => 
-    apiClient.put<T>(url, data, config),
-  
-  patch: <T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> => 
-    apiClient.patch<T>(url, data, config),
-  
-  delete: <T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> => 
-    apiClient.delete<T>(url, config),
+  get: <T>(
+    url: string,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> => apiClient.get<T>(url, config),
+
+  post: <T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> => apiClient.post<T>(url, data, config),
+
+  put: <T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> => apiClient.put<T>(url, data, config),
+
+  patch: <T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> => apiClient.patch<T>(url, data, config),
+
+  delete: <T>(
+    url: string,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> => apiClient.delete<T>(url, config),
 };
 
 // Artwork-specific API endpoints
 export const artworkApi = {
   // Get all artworks with optional pagination and filtering
-  getAll: (params?: { 
-    page?: number; 
-    limit?: number; 
+  getAll: (params?: {
+    page?: number;
+    limit?: number;
     search?: string;
     artist?: string;
     period?: string;
-  }) => 
-    api.get<ArtworkListResponse>('/artworks', { params }),
-  
+  }) => api.get<ArtworkListResponse>("/artworks", { params }),
+
   // Get single artwork by ID
-  getById: (id: string) => 
-    api.get<Artwork>(`/artworks/${id}`),
-  
+  getById: (id: string) => api.get<Artwork>(`/artworks/${id}`),
+
   // Get artwork provenance history
-  getProvenance: (id: string) => 
+  getProvenance: (id: string) =>
     api.get<ProvenanceRecord[]>(`/artworks/${id}/provenance`),
-  
+
   // Get enrichment data from external sources
-  getEnrichment: (id: string) => 
+  getEnrichment: (id: string) =>
     api.get<ArtworkEnrichment>(`/artworks/${id}/enrich`),
-  
+
   // Create new artwork
-  create: (data: CreateArtworkRequest) => 
-    api.post<Artwork>('/artworks', data),
-  
+  create: (data: CreateArtworkRequest) => api.post<Artwork>("/artworks", data),
+
   // Get QR code for artwork
-  getQRCode: (id: string) => 
-    api.get<Blob>(`/artworks/${id}/qr`, { responseType: 'blob' }),
+  getQRCode: (id: string) =>
+    api.get<Blob>(`/artworks/${id}/qr`, { responseType: "blob" }),
 };
 
 // SPARQL API endpoints
 export const sparqlApi = {
   // Execute a SPARQL query
-  query: (sparqlQuery: string) => 
-    api.post<SPARQLResponse>('/sparql', { query: sparqlQuery }),
+  query: (sparqlQuery: string) =>
+    api.post<SPARQLQueryResponse>("/sparql/query", { query: sparqlQuery }),
+
+  // Check Fuseki connection status
+  checkStatus: () => api.get<{ connected: boolean }>("/sparql/status"),
 };
 
 // Search API endpoints
 export const searchApi = {
   // Search artworks
-  search: (query: string, filters?: SearchFilters) => 
-    api.get<SearchResponse>('/search', { params: { q: query, ...filters } }),
-  
+  search: (query: string, filters?: SearchFilters) =>
+    api.get<SearchResponse>("/search", { params: { q: query, ...filters } }),
+
   // Get recommendations for an artwork
-  getRecommendations: (artworkId: string) => 
+  getRecommendations: (artworkId: string) =>
     api.get<Artwork[]>(`/artworks/${artworkId}/recommendations`),
 };
 
@@ -136,8 +154,8 @@ export interface Artwork {
     getty?: string;
   };
   // JSON-LD fields
-  '@context'?: Record<string, unknown>;
-  '@type'?: string;
+  "@context"?: Record<string, unknown>;
+  "@type"?: string;
 }
 
 export interface ProvenanceRecord {
@@ -240,6 +258,13 @@ export interface SPARQLResponse {
   };
 }
 
+// Wrapper response from backend SPARQL endpoint
+export interface SPARQLQueryResponse {
+  success: boolean;
+  results?: SPARQLResponse;
+  error?: string;
+}
+
 export interface SearchFilters {
   artist?: string;
   period?: string;
@@ -258,4 +283,3 @@ export interface SearchResponse {
 }
 
 export default apiClient;
-


### PR DESCRIPTION
- Implement CodeMirror-based SPARQL query editor with syntax highlighting
- Add 10 pre-built example queries matching ArP ontology schema
- Organize queries by category (Basic, Provenance, Analytics, Linked Data, Federated)
- Add CSV and JSON export functionality for query results
- Display results in responsive table with clickable URI links
- Show execution time and result count metrics
- Add Fuseki connection status indicator
- Support keyboard shortcuts (Ctrl+Enter to execute, Ctrl+L to clear)
- Add SPARQLQueryResponse type for backend API integration
- Add CSS animations for smooth UI transitions

Closes #12